### PR TITLE
fix(Flicking): Correct wrong restore event calls

### DIFF
--- a/src/Flicking.js
+++ b/src/Flicking.js
@@ -672,7 +672,7 @@ export default class Flicking extends Mixin(Component).with(eventHandler) {
 		 * @param {Number} param.direction Direction of the panel move (see eg.Flicking.DIRECTION_* constant) <ko>이동 방향(eg.Flicking.DIRECTION_* constant 참고)</ko>
 		 */
 		customEvent.restore && this._triggerEvent(consts.EVENTS.restore);
-		customEvent.restoreCall = false;
+		customEvent.restore = customEvent.restoreCall = false;
 	}
 
 	/**

--- a/test/unit/restore.spec.js
+++ b/test/unit/restore.spec.js
@@ -158,4 +158,42 @@ describe("restore() method", function() {
 			setTimeout(done, 300);
 		});
 	});
+
+	describe("After the restore event", function() {
+		tutils.hooks.run();
+
+		// Given
+		const $el = tutils.createFixture("#mflick1");
+
+		const inst = tutils.create($el, {
+			duration: 100,
+			hwAccelerable: true,
+			threshold: 100,
+			circular: true
+		});
+
+		it("Check for the custom event firing", done => {
+			tutils.simulator(inst.$wrapper, {
+				pos: [300, 0],
+				deltaX: -70,
+				deltaY: 0,
+				duration: 500
+			}, () => {
+				setTimeout(() => {
+					expect($el.eventFired).to.deep.equal(["flick", "beforeRestore", "flick", "restore"]);
+					$el.eventFired = [];
+					done();
+				}, 500)
+			});
+		});
+
+		it("check after the restore", done => {
+			inst.next();
+
+			setTimeout(() => {
+				expect($el.eventFired).to.deep.equal(["beforeFlickStart", "flick", "flickEnd"]);
+				done();
+			}, 500);
+		});
+	});
 });


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#23 

## Details
<!-- Detailed description of the change/feature -->
Fix to not be called restore event in normal flow, after restoration happening