### PR TITLE
chore(flicking.d.ts): Update to extends Component

### DIFF
--- a/src/flicking.d.ts
+++ b/src/flicking.d.ts
@@ -4,6 +4,8 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.2
 
+import * as Component from '@egjs/component';
+
 export as namespace eg;
 
 export = Flicking;
@@ -39,7 +41,7 @@ interface FlickingStatus {
   }[];
 }
 
-declare class Flicking {
+declare class Flicking extends Component {
   constructor(el: string | HTMLElement, options?: FlickingOption);
   destroy(): void;
   disableInput(): Flicking;


### PR DESCRIPTION
## Issue

## Details

![2018-01-16 10 42 05](https://user-images.githubusercontent.com/1321707/34991954-cebc884e-fb0e-11e7-9b5c-415c0cacd06d.png)

There is a problem i TS compilation because `Flicking` did not inherit the parent class `Component`.

