### PR TITLE
fix(resize): Remove updating container's width

### DIFF
--- a/src/Flicking.js
+++ b/src/Flicking.js
@@ -1422,11 +1422,7 @@ export default class Flicking extends Mixin(Component).with(eventHandler) {
 				panelSize = panel.size = utils.css(this.$wrapper, "width", true);
 			}
 
-			const max = panelSize * (panel.count - 1);
-			const maxCoords = this._getDataByDirection([max, 0]);
-
-			// resize elements
-			horizontal && utils.css(this.$container, {width: `${maxCoords[0] + panelSize}px`});
+			// resize panel elements
 			utils.css(panel.$list, {
 				[horizontal ? "width" : "height"]: utils.getUnitValue(panelSize)
 			});
@@ -1443,7 +1439,7 @@ export default class Flicking extends Mixin(Component).with(eventHandler) {
 				}
 			}
 
-			this._axesInst.axis.flick.range = [0, max];
+			this._axesInst.axis.flick.range = [0, panelSize * (panel.count - 1)];
 			this._setAxes("setTo", panelSize * panel.index, 0);
 
 			if (consts.IS_ANDROID2) {

--- a/test/unit/resize.spec.js
+++ b/test/unit/resize.spec.js
@@ -41,8 +41,8 @@ describe("resize() method", function() {
 			// The panel width should be same as current wrapper element
 			expect(panel.size).to.deep.equal(utils.css($el, "width", true));
 
-			// The panel container width should be same as current panels element total width
-			expect(utils.css(inst.$container, "width", true)).to.deep.equal(panel.count * panel.size);
+			// The panel container width should be same as current panel element width
+			expect(utils.css(inst.$container, "width", true)).to.deep.equal(panel.size);
 
 			// Should be updated Axes' 'max' options value
 			expect(oldCoordMax).to.not.deep.equal(inst._axesInst.axis.flick.range[1]);


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#77

## Details
<!-- Detailed description of the change/feature -->
There's no reason update container's width value as total panel's width.
It keeps to be 100% width to prevent styling issue.