### PR TITLE
fix(plugin): Correct for API moves

### DIFF
--- a/src/plugin/Plugin.js
+++ b/src/plugin/Plugin.js
@@ -83,9 +83,9 @@ export default class Plugin {
 	 */
 	_onFlick(e) {
 		const pos = e.pos;
-		const distance = e.distance;
+		const distance = e.distance || pos - this.$$._conf.panel.size;
 
-		this.onFlick && this.onFlick(pos, distance);
+		this.onFlick && this.onFlick(e, distance);
 	}
 
 	/**

--- a/src/plugin/effects/OpacityEffect.js
+++ b/src/plugin/effects/OpacityEffect.js
@@ -62,7 +62,7 @@ export default class OpacityEffect extends Plugin {
 	}
 
 	resize() {
-		this.size = Plugin.utils.css(this.$$.$wrapper, "width", true);
+		this.size = this.$$._conf.panel.size;
 		this.onRestore("resize");
 	}
 
@@ -82,16 +82,17 @@ export default class OpacityEffect extends Plugin {
 		/prev|resize/.test(type) && utils.classList(utils.css(this.details[2], {opacity: ""}), "selected", false);
 	}
 
-	onFlick(pos, offset) {
+	onFlick(e, distance) {
+		const pos = e.pos;
 		const per = (pos % this.size) / this.size;
 		const utils = Plugin.utils;
 
-		if (Math.abs(offset) >= this.size) {
+		if (Math.abs(distance) >= this.size) {
 			return;
 		}
 
-		const opacity = (offset > 0 && per <= 0.5 && 1 - (2 * per)) ||
-			(offset < 0 && per > 0.5 && 2 * (per - 0.5));
+		const opacity = (distance > 0 && per <= 0.5 && 1 - (2 * per)) ||
+			(distance < 0 && per > 0.5 && 2 * (per - 0.5));
 
 		if (opacity !== undefined) {
 			utils.css(this.details[1], {opacity});

--- a/src/plugin/effects/ParallaxEffect.js
+++ b/src/plugin/effects/ParallaxEffect.js
@@ -97,23 +97,24 @@ export default class ParallaxEffect extends Plugin {
 		/prev|resize/.test(type) && utils.css(this.imgs[0], {transform: utils.translate("-50%", 0, useLayerHack)});
 	}
 
-	onFlick(pos, offset) {
+	onFlick(e, distance) {
 		const utils = Plugin.utils;
+		const pos = e.pos;
 		const maxRange = this.size;
 		const delta = (pos % maxRange) / 2;
 		const siblingDelta = -(maxRange / 2 - delta);
 		const useLayerHack = this.options.useLayerHack;
 
-		if (Math.abs(offset) >= maxRange) {
+		if (Math.abs(distance) >= maxRange) {
 			return;
 		}
 
 		const update = [];
 
-		if (offset > 0) {
+		if (distance > 0) {
 			update.push({el: this.imgs[1], x: delta});
 			update.push({el: this.imgs[2], x: siblingDelta});
-		} else if (offset < 0) {
+		} else if (distance < 0) {
 			update.push({el: this.imgs[1], x: siblingDelta});
 			update.push({el: this.imgs[0], x: delta});
 		}
@@ -128,9 +129,7 @@ export default class ParallaxEffect extends Plugin {
 	}
 
 	resize() {
-		const $$ = this.$$;
-
-		this.size = Plugin.utils.css($$.$wrapper, "width", true);
+		this.size = this.$$._conf.panel.size;
 		this.onRestore("resize");
 	}
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
#103

## Details
<!-- Detailed description of the change/feature -->
Correct mal-functioning when move APIs(.next()/.prev()) called