### PR TITLE
fix: recalculate target panel when interrupted

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -213,7 +213,6 @@ class Flicking extends Component {
       panel,
       eventType,
       null,
-      offset,
       duration,
     );
     return this;
@@ -246,7 +245,7 @@ class Flicking extends Component {
     const viewport = this.viewport;
     const panel = viewport.getCurrentPanel();
     return panel
-      ? viewport.castToFlickingPanel(panel)
+      ? panel
       : null;
   }
 
@@ -259,7 +258,7 @@ class Flicking extends Component {
     const viewport = this.viewport;
     const panel = viewport.panelManager.get(index);
     return panel
-      ? viewport.castToFlickingPanel(panel)
+      ? panel
       : null;
   }
 
@@ -277,8 +276,7 @@ class Flicking extends Component {
       : panelManager.originalPanels();
 
     return panels
-      .filter(panel => !!panel)
-      .map(panel => viewport.castToFlickingPanel(panel));
+      .filter(panel => !!panel);
   }
 
   /**

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -167,7 +167,7 @@ class Panel implements FlickingPanel {
     const newPosition = currentPosition - prevPanelSize - options.gap;
 
     let prevPanel = prevSibling;
-    if (prevPanelPosition >= currentPosition) {
+    if (prevPanelPosition !== newPosition) {
       prevPanel = prevSibling.clone(prevSibling.getCloneIndex(), true);
       prevPanel.setPosition(newPosition, true);
     }
@@ -202,7 +202,7 @@ class Panel implements FlickingPanel {
     const newPosition = currentPosition + this.getSize() + options.gap;
 
     let nextPanel = nextSibling;
-    if (nextPanelPosition <= currentPosition) {
+    if (nextPanelPosition !== newPosition) {
       nextPanel = nextSibling.clone(nextSibling.getCloneIndex(), true);
       nextPanel.setPosition(newPosition, true);
     }

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -133,7 +133,6 @@ class Panel implements FlickingPanel {
       ? ""
       : EVENTS.CHANGE;
 
-    console.log(duration);
     viewport.moveTo(this, eventType, null, duration);
   }
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -1,15 +1,18 @@
-import { OriginalStyle, FlickingOptions } from "../types";
-import { DEFAULT_PANEL_CSS } from "../consts";
-import { addClass, applyCSS, parseArithmeticExpression } from "../utils";
+import Viewport from "./Viewport";
+import { OriginalStyle, FlickingPanel, ElementLike } from "../types";
+import { DEFAULT_PANEL_CSS, EVENTS } from "../consts";
+import { addClass, applyCSS, parseArithmeticExpression, parseElement, getProgress } from "../utils";
 
-class Panel {
+class Panel implements FlickingPanel {
   public prevSibling: Panel | null;
   public nextSibling: Panel | null;
 
   private element: HTMLElement;
+  private viewport: Viewport;
   private state: {
     index: number;
     position: number;
+    loop: number;
     relativeAnchorPosition: number;
     size: number;
     isClone: boolean;
@@ -20,21 +23,22 @@ class Panel {
     clonedPanels: Panel[];
     cachedBbox: ClientRect | null;
   };
-  private options: FlickingOptions;
   private original?: Panel;
 
   public constructor(
     element: HTMLElement,
     index: number,
-    options: FlickingOptions,
+    viewport: Viewport,
   ) {
     this.element = element;
+    this.viewport = viewport;
     this.prevSibling = null;
     this.nextSibling = null;
 
     this.state = {
       index,
       position: 0,
+      loop: 0,
       relativeAnchorPosition: 0,
       size: 0,
       clonedPanels: [],
@@ -46,7 +50,8 @@ class Panel {
       },
       cachedBbox: null,
     };
-    this.options = options;
+
+    const options = viewport.options;
 
     if (options.classPrefix) {
       addClass(element, `${options.classPrefix}-panel`);
@@ -58,12 +63,13 @@ class Panel {
 
   public resize(): void {
     const state = this.state;
+    const options = this.viewport.options;
     const bbox = this.getBbox();
 
-    state.size = this.options.horizontal
+    state.size = options.horizontal
       ? bbox.width
       : bbox.height;
-    state.relativeAnchorPosition = parseArithmeticExpression(this.options.anchor, state.size);
+    state.relativeAnchorPosition = parseArithmeticExpression(options.anchor, state.size);
 
     if (!state.isClone) {
       state.clonedPanels.forEach(panel => panel.resize());
@@ -72,6 +78,170 @@ class Panel {
 
   public reset(): void {
     this.state.cachedBbox = null;
+  }
+
+  public getProgress() {
+    const viewport = this.viewport;
+    const options = viewport.options;
+    const panelCount = viewport.panelManager.getPanelCount();
+    const scrollAreaSize = viewport.getScrollAreaSize();
+
+    const relativeIndex = (options.circular ? Math.floor(this.getPosition() / scrollAreaSize) * panelCount : 0) + this.getIndex();
+    const progress = relativeIndex - viewport.getCurrentProgress();
+
+    return progress;
+  }
+
+  public getOutsetProgress() {
+    const viewport = this.viewport;
+    const outsetRange = [
+      -this.getSize(),
+      viewport.getRelativeHangerPosition() - this.getRelativeAnchorPosition(),
+      viewport.getSize(),
+    ];
+    const relativePanelPosition = this.getPosition() - viewport.getCameraPosition();
+    const outsetProgress = getProgress(relativePanelPosition, outsetRange);
+
+    return outsetProgress;
+  }
+
+  public getVisibleRatio() {
+    const viewport = this.viewport;
+    const panelSize = this.getSize();
+    const relativePanelPosition = this.getPosition() - viewport.getCameraPosition();
+    const rightRelativePanelPosition = relativePanelPosition + panelSize;
+
+    const visibleSize = Math.min(viewport.getSize(), rightRelativePanelPosition) - Math.max(relativePanelPosition, 0);
+    const visibleRatio = visibleSize >= 0
+      ? visibleSize / panelSize
+      : 0;
+
+    return visibleRatio;
+  }
+
+  public focus(duration?: number): void {
+    const viewport = this.viewport;
+    const currentPanel = viewport.getCurrentPanel();
+    const hangerPosition = viewport.getHangerPosition();
+    const anchorPosition = this.getAnchorPosition();
+    if (hangerPosition === anchorPosition || !currentPanel) {
+      return;
+    }
+
+    const currentPosition = currentPanel.getPosition();
+    const eventType = currentPosition === this.getPosition()
+      ? ""
+      : EVENTS.CHANGE;
+
+    console.log(duration);
+    viewport.moveTo(this, eventType, null, duration);
+  }
+
+  public update(updateFunction: (element: HTMLElement) => any): void {
+    this.getIdenticalPanels()
+      .forEach(eachPanel => updateFunction(eachPanel.getElement()));
+  }
+
+  public prev(): FlickingPanel | null {
+    const viewport = this.viewport;
+    const options = viewport.options;
+    const prevSibling = this.prevSibling;
+
+    if (!prevSibling) {
+      return null;
+    }
+
+    const currentIndex = this.getIndex();
+    const currentPosition = this.getPosition();
+    const prevPanelIndex = prevSibling.getIndex();
+    const prevPanelPosition = prevSibling.getPosition();
+    const prevPanelSize = prevSibling.getSize();
+
+    const hasEmptyPanelBetween = currentIndex - prevPanelIndex > 1;
+    const notYetMinPanel = options.infinite
+      && currentIndex > 0
+      && prevPanelIndex > currentIndex;
+
+    if (hasEmptyPanelBetween || notYetMinPanel) {
+      // Empty panel exists between
+      return null;
+    }
+
+    const newPosition = currentPosition - prevPanelSize - options.gap;
+
+    let prevPanel = prevSibling;
+    if (prevPanelPosition >= currentPosition) {
+      prevPanel = prevSibling.clone(prevSibling.getCloneIndex(), true);
+      prevPanel.setPosition(newPosition, true);
+      if (prevPanelIndex >= currentIndex) {
+        prevPanel.setLoopIndex(this.getLoopIndex() - 1);
+      }
+    }
+
+    return prevPanel;
+  }
+
+  public next(): FlickingPanel | null {
+    const viewport = this.viewport;
+    const options = viewport.options;
+    const nextSibling = this.nextSibling;
+    const lastIndex = viewport.panelManager.getLastIndex();
+
+    if (!nextSibling) {
+      return null;
+    }
+
+    const currentIndex = this.getIndex();
+    const currentPosition = this.getPosition();
+    const nextPanelIndex = nextSibling.getIndex();
+    const nextPanelPosition = nextSibling.getPosition();
+
+    const hasEmptyPanelBetween = nextPanelIndex - currentIndex > 1;
+    const notYetMaxPanel = options.infinite
+      && currentIndex < lastIndex
+      && nextPanelIndex < currentIndex;
+
+    if (hasEmptyPanelBetween || notYetMaxPanel) {
+      return null;
+    }
+
+    const newPosition = currentPosition + this.getSize() + options.gap;
+
+    let nextPanel = nextSibling;
+    if (nextPanelPosition <= currentPosition) {
+      nextPanel = nextSibling.clone(nextSibling.getCloneIndex(), true);
+      nextPanel.setPosition(newPosition, true);
+      if (nextPanelIndex <= currentIndex) {
+        nextPanel.setLoopIndex(this.getLoopIndex() + 1);
+      }
+    }
+
+    return nextPanel;
+  }
+
+  public insertBefore(element: ElementLike | ElementLike[]): FlickingPanel[] {
+    const viewport = this.viewport;
+    const parsedElements = parseElement(element);
+    const firstPanel = viewport.panelManager.firstPanel()!;
+    const prevSibling = this.prevSibling;
+    // Finding correct inserting index
+    // While it should insert removing empty spaces,
+    // It also should have to be bigger than prevSibling' s index
+    const targetIndex = prevSibling && firstPanel.getIndex() !== this.getIndex()
+      ? Math.max(prevSibling.getIndex() + 1, this.getIndex() - parsedElements.length)
+      : Math.max(this.getIndex() - parsedElements.length, 0);
+
+    return viewport.insert(targetIndex, parsedElements);
+  }
+
+  public insertAfter(element: ElementLike | ElementLike[]): FlickingPanel[] {
+    return this.viewport.insert(this.getIndex() + 1, element);
+  }
+
+  public remove(): FlickingPanel {
+    this.viewport.remove(this.getIndex());
+
+    return this;
   }
 
   public destroy(): void {
@@ -109,6 +279,10 @@ class Panel {
 
   public getPosition(): number {
     return this.state.position;
+  }
+
+  public getLoopIndex(): number {
+    return this.state.loop;
   }
 
   public getSize(): number {
@@ -153,29 +327,37 @@ class Panel {
       : this;
   }
 
-  public setIndex(index: number) {
+  public setIndex(index: number): void {
     const state = this.state;
 
     state.index = index;
     state.clonedPanels.forEach(panel => panel.state.index = index);
   }
 
-  public setPosition(pos: number) {
+  public setPosition(pos: number, virtual: boolean = false): void {
     const state = this.state;
-    const options = this.options;
+    const options = this.viewport.options;
     const elementStyle = this.element.style;
 
     state.position = pos;
-    options.horizontal
-      ? elementStyle.left = `${pos}px`
-      : elementStyle.top = `${pos}px`;
+    if (!virtual) {
+      options.horizontal
+        ? elementStyle.left = `${pos}px`
+        : elementStyle.top = `${pos}px`;
+    }
   }
 
-  public clone(cloneIndex: number): Panel {
+  public setLoopIndex(index: number): void {
+    this.state.loop = index;
+  }
+
+  public clone(cloneIndex: number, virtual: boolean = false): Panel {
     const state = this.state;
 
-    const cloneElement = this.element.cloneNode(true) as HTMLElement;
-    const clonedPanel = new Panel(cloneElement, state.index, this.options);
+    const cloneElement = virtual
+      ? this.element
+      : this.element.cloneNode(true) as HTMLElement;
+    const clonedPanel = new Panel(cloneElement, state.index, this.viewport);
     const clonedState = clonedPanel.state;
 
     clonedPanel.original = this;
@@ -186,15 +368,22 @@ class Panel {
     clonedState.relativeAnchorPosition = state.relativeAnchorPosition;
     clonedState.originalStyle = state.originalStyle;
     clonedState.cachedBbox = state.cachedBbox;
-    state.clonedPanels.push(clonedPanel);
+
+    if (!virtual) {
+      state.clonedPanels.push(clonedPanel);
+    } else {
+      clonedPanel.prevSibling = this.prevSibling;
+      clonedPanel.nextSibling = this.nextSibling;
+    }
 
     return clonedPanel;
   }
 
-  public remove(): void {
+  public removeElement(): void {
     const element = this.element;
     element.parentNode!.removeChild(element);
 
+    // Do the same thing for clones
     if (!this.state.isClone) {
       this.removeClonedPanelsAfter(0);
     }
@@ -205,7 +394,7 @@ class Panel {
     const removingPanels = state.clonedPanels.splice(start);
 
     removingPanels.forEach(panel => {
-      panel.remove();
+      panel.removeElement();
     });
   }
 }

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -12,7 +12,6 @@ class Panel implements FlickingPanel {
   private state: {
     index: number;
     position: number;
-    loop: number;
     relativeAnchorPosition: number;
     size: number;
     isClone: boolean;
@@ -38,7 +37,6 @@ class Panel implements FlickingPanel {
     this.state = {
       index,
       position: 0,
-      loop: 0,
       relativeAnchorPosition: 0,
       size: 0,
       clonedPanels: [],
@@ -172,9 +170,6 @@ class Panel implements FlickingPanel {
     if (prevPanelPosition >= currentPosition) {
       prevPanel = prevSibling.clone(prevSibling.getCloneIndex(), true);
       prevPanel.setPosition(newPosition, true);
-      if (prevPanelIndex >= currentIndex) {
-        prevPanel.setLoopIndex(this.getLoopIndex() - 1);
-      }
     }
 
     return prevPanel;
@@ -210,9 +205,6 @@ class Panel implements FlickingPanel {
     if (nextPanelPosition <= currentPosition) {
       nextPanel = nextSibling.clone(nextSibling.getCloneIndex(), true);
       nextPanel.setPosition(newPosition, true);
-      if (nextPanelIndex <= currentIndex) {
-        nextPanel.setLoopIndex(this.getLoopIndex() + 1);
-      }
     }
 
     return nextPanel;
@@ -280,10 +272,6 @@ class Panel implements FlickingPanel {
     return this.state.position;
   }
 
-  public getLoopIndex(): number {
-    return this.state.loop;
-  }
-
   public getSize(): number {
     return this.state.size;
   }
@@ -344,10 +332,6 @@ class Panel implements FlickingPanel {
         ? elementStyle.left = `${pos}px`
         : elementStyle.top = `${pos}px`;
     }
-  }
-
-  public setLoopIndex(index: number): void {
-    this.state.loop = index;
   }
 
   public clone(cloneIndex: number, virtual: boolean = false): Panel {

--- a/src/components/PanelManager.ts
+++ b/src/components/PanelManager.ts
@@ -92,7 +92,7 @@ class PanelManager {
     const range = this.range;
     if (lastPanel.getIndex() > lastIndex) {
       const removingPanels = this.panels.splice(lastIndex + 1);
-      removingPanels.forEach(panel => panel.remove());
+      removingPanels.forEach(panel => panel.removeElement());
       this.length -= removingPanels.length;
 
       const firstRemovedPanel = removingPanels.filter(panel => !!panel)[0];
@@ -166,7 +166,7 @@ class PanelManager {
       if (panels.length > lastIndex + 1) {
         const removedPanels = panels.splice(lastIndex + 1)
           .filter(panel => Boolean(panel));
-        removedPanels.forEach(panel => panel.remove());
+        removedPanels.forEach(panel => panel.removeElement());
         this.length -= removedPanels.length;
       }
     }
@@ -221,7 +221,7 @@ class PanelManager {
     const wasNonEmptyCount = replacedPanels.filter(panel => Boolean(panel)).length;
     replacedPanels.forEach(panel => {
       if (panel) {
-        panel.remove();
+        panel.removeElement();
       }
     });
 
@@ -247,7 +247,7 @@ class PanelManager {
       .filter(panel => !!panel);
 
     deletedPanels.forEach(panel => {
-      panel.remove();
+      panel.removeElement();
     });
 
     if (isCircular) {
@@ -366,8 +366,7 @@ class PanelManager {
   // Clear both original & cloned
   public clear(): void {
     this.panels.forEach(panel => {
-      panel.remove();
-      panel.removeClonedPanelsAfter(0);
+      panel.removeElement();
     });
 
     this.panels = [];

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -904,7 +904,6 @@ export default class Viewport {
       const clonedPanelPos = cloneBasePos + origPanel.getPosition();
 
       panel.setPosition(clonedPanelPos);
-      panel.setLoopIndex(cloneIndex + 1);
     }
 
     let lastReplacePosition = firstPanel.getPosition();
@@ -912,9 +911,6 @@ export default class Viewport {
     for (const panel of clonedPanels.concat().reverse()) {
       const panelSize = panel.getSize();
       const replacePosition = lastReplacePosition - panelSize - options.gap;
-      const cloneIndex = panel.getCloneIndex();
-      const maxCloneCount = panelManager.getCloneCount();
-      const loopIndex = cloneIndex - maxCloneCount;
 
       if (replacePosition + panelSize <= scrollArea.prev) {
         // Replace is not meaningful, as it won't be seen in current scroll area
@@ -922,7 +918,6 @@ export default class Viewport {
       }
 
       panel.setPosition(replacePosition);
-      panel.setLoopIndex(loopIndex);
       lastReplacePosition = replacePosition;
     }
   }

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -119,6 +119,8 @@ export default class Viewport {
     }
 
     eventResult.onSuccess(() => {
+      currentState.delta = 0;
+      currentState.lastPosition = this.getCameraPosition();
       currentState.targetPanel = panel;
       currentState.direction = estimatedPosition > currentPosition
         ? DIRECTION.NEXT

--- a/src/states/AnimatingState.ts
+++ b/src/states/AnimatingState.ts
@@ -13,7 +13,7 @@ class AnimatingState extends State {
     const scrollAreaSize = viewport.getScrollAreaSize();
     const loopCount = Math.floor((this.lastPosition + this.delta - scrollArea.prev) / scrollAreaSize);
 
-    let targetPanel = this.targetPanel;
+    const targetPanel = this.targetPanel;
     if (loopCount !== 0 && targetPanel) {
       const cloneCount = viewport.panelManager.getCloneCount();
       const originalTargetPosition = targetPanel.getPosition();

--- a/src/states/DraggingState.ts
+++ b/src/states/DraggingState.ts
@@ -10,11 +10,6 @@ class DraggingState extends State {
   public readonly holding = true;
   public readonly playing = true;
 
-  public onEnter(prevState: State): void {
-    super.onEnter(prevState);
-    this.delta = 0;
-  }
-
   public onChange(e: any, { moveCamera, transitTo }: FlickingContext): void {
     if (!e.delta.flick) {
       return;
@@ -64,7 +59,6 @@ class DraggingState extends State {
 
     // Update last position to cope with Axes's animating behavior
     // Axes uses start position when animation start
-    this.lastPosition = viewport.getCameraPosition();
     triggerEvent(EVENTS.HOLD_END, e, true);
 
     if (!overThreshold && this.targetPanel) {
@@ -141,6 +135,7 @@ class DraggingState extends State {
         ? ""
         : EVENTS.RESTORE
       : EVENTS.CHANGE;
+
 
     viewport.moveTo(
       panelToMove,

--- a/src/states/DraggingState.ts
+++ b/src/states/DraggingState.ts
@@ -132,7 +132,6 @@ class DraggingState extends State {
         : EVENTS.RESTORE
       : EVENTS.CHANGE;
 
-
     viewport.moveTo(
       panelToMove,
       eventType,

--- a/src/states/DraggingState.ts
+++ b/src/states/DraggingState.ts
@@ -69,7 +69,7 @@ class DraggingState extends State {
 
     if (!overThreshold && this.targetPanel) {
       // Interrupted while animating
-      viewport.moveTo(this.targetPanel, "", e, this.targetOffset);
+      viewport.moveTo(this.targetPanel, "", e);
       transitTo(STATE_TYPE.ANIMATING);
       return;
     }
@@ -146,7 +146,6 @@ class DraggingState extends State {
       panelToMove,
       eventType,
       e,
-      offset,
       duration,
     ).onSuccess(() => {
       transitTo(STATE_TYPE.ANIMATING);

--- a/src/states/HoldingState.ts
+++ b/src/states/HoldingState.ts
@@ -82,7 +82,7 @@ class HoldingState extends State {
       triggerEvent(EVENTS.SELECT, null, true, {
         direction, // Direction to the clicked panel
         index: clickedPanel.getIndex(),
-        panel: viewport.castToFlickingPanel(clickedPanel),
+        panel: clickedPanel,
       });
     }
   }

--- a/src/states/IdleState.ts
+++ b/src/states/IdleState.ts
@@ -11,7 +11,6 @@ class IdleState extends State {
     this.direction = null;
     this.targetPanel = null;
     this.delta = 0;
-    this.targetOffset = 0;
     this.lastPosition = 0;
   }
 

--- a/src/states/State.ts
+++ b/src/states/State.ts
@@ -5,7 +5,6 @@ abstract class State {
   public delta: number = 0;
   public direction: ValueOf<Direction> | null = null;
   public targetPanel: Panel | null = null;
-  public targetOffset: number = 0;
   public lastPosition: number = 0;
   public abstract readonly type: ValueOf<StateType>;
   public abstract readonly holding: boolean;
@@ -15,7 +14,6 @@ abstract class State {
     this.delta = prevState.delta;
     this.direction = prevState.direction;
     this.targetPanel = prevState.targetPanel;
-    this.targetOffset = prevState.targetOffset;
     this.lastPosition = prevState.lastPosition;
   }
   public onExit(nextState: State): void {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,3 +207,17 @@ export function counter(max: number): number[] {
   }
   return counterArray;
 }
+
+// Circulate number between range [min, max]
+export function circulate(value: number, min: number, max: number): number {
+  const size = max - min + 1;
+  if (value < min) {
+    const offset = (value - min + 1) % size; // is minus value
+    value = max + offset;
+  } else if (value > max) {
+    const offset = (value - max - 1) % size;
+    value = min + offset
+  }
+
+  return value;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,7 +216,7 @@ export function circulate(value: number, min: number, max: number): number {
     value = max + offset;
   } else if (value > max) {
     const offset = (value - max - 1) % size;
-    value = min + offset
+    value = min + offset;
   }
 
   return value;

--- a/test/manual/test.js
+++ b/test/manual/test.js
@@ -156,7 +156,7 @@ setTimeout(function() {
       gap: 10,
       duration: 300,
       autoResize: true
-    })
+    });
     f2c = createFlicking("#flick2-3", {
       circular: true,
       autoResize: true

--- a/test/manual/test.js
+++ b/test/manual/test.js
@@ -154,9 +154,9 @@ setTimeout(function() {
     f2b = createFlicking("#flick2-2", {
       circular: true,
       gap: 10,
-      duration: 300,
+      duration: 3000,
       autoResize: true
-    });
+    }).on("select", e => e.panel.prev().prev().prev().focus(3000));
     f2c = createFlicking("#flick2-3", {
       circular: true,
       autoResize: true

--- a/test/unit/Panel.spec.ts
+++ b/test/unit/Panel.spec.ts
@@ -1,0 +1,157 @@
+import Flicking from "../../src/Flicking";
+import { FlickingEvent, FlickingOptions } from "../../src/types";
+import { cleanup, createFlicking } from "./assets/utils";
+import { horizontal } from "./assets/fixture";
+import { counter } from "../../src/utils";
+
+describe("Panel", () => {
+  let flickingInfo: {
+    element: HTMLElement,
+    instance: Flicking,
+    events: FlickingEvent[],
+    eventFired: string[],
+    eventDirection: string[],
+  };
+  let flicking: Flicking;
+
+  beforeEach(() => {
+    initFlicking(horizontal.full);
+  });
+
+  afterEach(() => cleanup());
+
+  const initFlicking = (type: string, options?: Partial<FlickingOptions>) => {
+    flickingInfo = createFlicking(type, options);
+    flicking = flickingInfo.instance;
+  }
+
+  describe("next()", () => {
+    it("can return correct next panel", () => {
+      // Given
+      const currentPanel = flicking.getCurrentPanel();
+
+      // When
+      const nextPanel = currentPanel.next();
+
+      // Then
+      expect(nextPanel.getIndex()).equals(currentPanel.getIndex() + 1);
+      expect(nextPanel.getPosition()).equals(currentPanel.getPosition() + currentPanel.getSize());
+      expect(nextPanel).deep.equals(flicking.getPanel(currentPanel.getIndex() + 1));
+    });
+
+    it("will return null if called at last panel in non-circular mode", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: false });
+      const lastPanel = flicking.getPanel(flicking.getPanelCount() - 1);
+
+      // When
+      const shouldBeNull = lastPanel.next();
+
+      // Then
+      expect(shouldBeNull).to.be.null;
+    });
+
+    it("can return virtual panel in circular mode", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: true });
+      const lastPanel = flicking.getPanel(flicking.getPanelCount() - 1);
+      const panelSize = lastPanel.getSize(); // All panels have same size
+      const nextCount = 100;
+      let nextPanel = lastPanel;
+
+      // When
+      counter(nextCount).forEach(() => {
+        nextPanel = nextPanel.next();
+      });
+
+      // Then
+      const expectedIndex = (lastPanel.getIndex() + nextCount) % flicking.getPanelCount();
+      expect(nextPanel.getIndex()).equals(expectedIndex);
+      expect(nextPanel.getPosition()).equals(lastPanel.getPosition() + panelSize * nextCount);
+    });
+
+    it("should return virtual panel after successive prev() calls", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: true });
+      const firstPanel = flicking.getPanel(0);
+      const prevCount = 100;
+      let virtualPrevPanel = firstPanel;
+
+      // When
+      counter(prevCount).forEach(() => {
+        virtualPrevPanel = virtualPrevPanel.prev();
+      });
+      const nextPanel = virtualPrevPanel.next();
+
+      // Then
+      expect(nextPanel.getPosition())
+        .equals(virtualPrevPanel.getPosition() + virtualPrevPanel.getSize());
+    });
+  });
+
+  describe("prev()", () => {
+    it("can return correct prev panel", () => {
+      // Given
+      initFlicking(horizontal.full, { defaultIndex: 2 });
+      const currentPanel = flicking.getCurrentPanel();
+
+      // When
+      const prevPanel = currentPanel.prev();
+
+      // Then
+      expect(prevPanel.getIndex()).equals(currentPanel.getIndex() - 1);
+      expect(prevPanel.getPosition()).equals(currentPanel.getPosition() - prevPanel.getSize());
+      expect(prevPanel).deep.equals(flicking.getPanel(currentPanel.getIndex() - 1));
+    });
+
+    it("will return null if called at first panel in non-circular mode", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: false });
+      const firstPanel = flicking.getPanel(0);
+
+      // When
+      const shouldBeNull = firstPanel.prev();
+
+      // Then
+      expect(shouldBeNull).to.be.null;
+    });
+
+    it("can return virtual panel in circular mode", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: true });
+      const firstPanel = flicking.getPanel(0);
+      const panelSize = firstPanel.getSize(); // All panels have same size
+      const prevCount = 100;
+      let prevPanel = firstPanel;
+
+      // When
+      counter(prevCount).forEach(() => {
+        prevPanel = prevPanel.prev();
+      });
+
+      // Then
+      const lastIndex = flicking.getPanelCount() - 1;
+      const expectedIndex = lastIndex + (firstPanel.getIndex() - prevCount + 1) % flicking.getPanelCount();
+      expect(prevPanel.getIndex()).equals(expectedIndex);
+      expect(prevPanel.getPosition()).equals(firstPanel.getPosition() - panelSize * prevCount);
+    });
+
+    it("should return virtual panel after successive next() calls", () => {
+      // Given
+      initFlicking(horizontal.full, { circular: true });
+      const firstPanel = flicking.getPanel(0);
+      const nextCount = 100;
+      let virtualNextPanel = firstPanel;
+
+      // When
+      counter(nextCount).forEach(() => {
+        virtualNextPanel = virtualNextPanel.next();
+      });
+      const prevPanel = virtualNextPanel.prev();
+
+      // Then
+      expect(prevPanel.getPosition())
+        .equals(virtualNextPanel.getPosition() - prevPanel.getSize());
+    });
+  });
+});

--- a/test/unit/PanelManager.spec.ts
+++ b/test/unit/PanelManager.spec.ts
@@ -4,9 +4,8 @@ import Flicking from "../../src/Flicking";
 import Panel from "../../src/components/Panel";
 import Viewport from "../../src/components/Viewport";
 import PanelManager from "../../src/components/PanelManager";
-import { DEFAULT_OPTIONS } from "../../src/consts";
-import { counter, merge } from "../../src/utils";
-import { FlickingOptions, FlickingEvent } from "../../src/types";
+import { counter } from "../../src/utils";
+import { FlickingEvent } from "../../src/types";
 import { cleanup, createFlicking } from "./assets/utils";
 import { horizontal } from "./assets/fixture";
 

--- a/test/unit/assets/utils.ts
+++ b/test/unit/assets/utils.ts
@@ -1,8 +1,7 @@
 import Component from "@egjs/component";
 import Flicking from "../../../src/Flicking";
-import Panel from "../../../src/components/Panel";
 import { merge, counter } from "../../../src/utils";
-import { EVENTS, DEFAULT_OPTIONS } from "../../../src/consts";
+import { EVENTS } from "../../../src/consts";
 import { FlickingEvent, FlickingOptions } from "../../../src/types";
 
 export function createFixture(type: string): HTMLElement {
@@ -57,18 +56,6 @@ export function createFlicking(type: string, option: Partial<FlickingOptions> = 
     eventFired,
     eventDirection,
   };
-}
-
-export function createPanel(idx: number, parentElement?: HTMLElement): Panel {
-  // Parent element should be exist,
-  // as panel element can be removed when remove() is called
-  if (!parentElement) {
-    parentElement = document.createElement("div");
-  }
-  const panelElement = document.createElement("div");
-  parentElement.appendChild(panelElement);
-
-  return new Panel(panelElement, idx, merge({}, DEFAULT_OPTIONS) as FlickingOptions);
 }
 
 export function cleanup() {

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -636,15 +636,15 @@ describe("Methods call", () => {
       await waitFor(100);
 
       // Then
-      expect(restore.callCount).to.be.equals(0);
-      expect(change.callCount).to.be.equals(0);
-      expect(moveEnd.callCount).to.be.equals(2);
-      expect(index).to.be.equals(0);
-      expect(flickingInfo.instance.getIndex()).to.be.equals(0);
+      expect(restore.callCount).to.be.equal(0);
+      expect(change.callCount).to.be.equal(0);
+      expect(moveEnd.callCount).to.be.equal(2);
+      expect(index).to.be.equal(0);
+      expect(flicking.getIndex()).to.be.equal(0);
       // progress1
-      expect(moveEnd.args[0][0].progress).to.be.not.equals(0);
+      expect(moveEnd.args[0][0].progress).to.be.not.equal(0);
       // progress2
-      expect(moveEnd.args[1][0].progress).to.be.equals(0);
+      expect(moveEnd.args[1][0].progress).to.be.equal(0);
     });
 
     it("should check 'freeScroll' option(strong snap)", async () => {


### PR DESCRIPTION
## Issue
Fixes #171 
It also resolves #174 

## Details
- This changes internal interface from FlickingPanel to real Panel's instance
- #171 is now fixed.
- #174 is also handled on this PR.