### PR TITLE
fix: calling stop() to stop event immediately

### DIFF
--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -590,6 +590,16 @@ export default class Viewport {
     return startIndex + progressBetween;
   }
 
+  // Update axes flick position without triggering event
+  public updateAxesPosition(position: number) {
+    const axes = this.axes;
+    axes.off();
+    axes.setTo({
+      flick: position,
+    }, 0);
+    axes.on(this.axesHandlers);
+  }
+
   public getSize(): number {
     return this.state.size;
   }
@@ -984,7 +994,6 @@ export default class Viewport {
   // Update camera position after resizing
   private updateCameraPosition(): void {
     const state = this.state;
-    const axes = this.axes;
     const currentPanel = this.getCurrentPanel();
     const currentState = this.stateMachine.getState();
     const isFreeScroll = (this.options.moveType as MoveTypeObjectOption).type === "freeScroll";
@@ -1003,11 +1012,8 @@ export default class Viewport {
 
     // Pause & resume axes to prevent axes's "change" event triggered
     // This should be done before moveCamera, as moveCamera can trigger needPanel
-    this.axes.off();
-    axes.setTo({
-      flick: newPosition,
-    }, 0);
-    this.axes.on(this.axesHandlers);
+    this.updateAxesPosition(newPosition);
+
     this.moveCamera(newPosition);
   }
 

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -993,7 +993,9 @@ export default class Viewport {
       return;
     }
 
-    let newPosition = currentPanel.getAnchorPosition() - state.relativeHangerPosition;
+    let newPosition = currentPanel
+      ? currentPanel.getAnchorPosition() - state.relativeHangerPosition
+      : this.getCameraPosition();
 
     if (this.canSetBoundMode()) {
       newPosition = clamp(newPosition, state.scrollArea.prev, state.scrollArea.next);

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -998,7 +998,7 @@ export default class Viewport {
     const currentState = this.stateMachine.getState();
     const isFreeScroll = (this.options.moveType as MoveTypeObjectOption).type === "freeScroll";
 
-    if (!currentPanel || currentState.holding || currentState.playing || isFreeScroll) {
+    if (currentState.holding || currentState.playing || isFreeScroll) {
       return;
     }
 

--- a/src/states/DisabledState.ts
+++ b/src/states/DisabledState.ts
@@ -11,6 +11,12 @@ class DisabledState extends State {
     transitTo(STATE_TYPE.IDLE);
   }
 
+  public onChange(e: any, { transitTo }: FlickingContext): void {
+    // Can stop Axes's change event
+    e.stop();
+    transitTo(STATE_TYPE.IDLE);
+  }
+
   public onRelease(e: any, { transitTo }: FlickingContext): void {
     // This is needed when stopped hold start event
     if (e.delta.flick === 0) {

--- a/src/states/DisabledState.ts
+++ b/src/states/DisabledState.ts
@@ -11,9 +11,12 @@ class DisabledState extends State {
     transitTo(STATE_TYPE.IDLE);
   }
 
-  public onChange(e: any, { transitTo }: FlickingContext): void {
+  public onChange(e: any, { viewport, transitTo }: FlickingContext): void {
     // Can stop Axes's change event
     e.stop();
+
+    // Should update axes position as it's already changed at this moment
+    viewport.updateAxesPosition(viewport.getCameraPosition());
     transitTo(STATE_TYPE.IDLE);
   }
 

--- a/test/manual/test.js
+++ b/test/manual/test.js
@@ -250,7 +250,8 @@ setTimeout(function() {
       autoResize: true
     }).on({
       holdStart: function(e) {
-        e.stop()
+        e.stop();
+        console.log(e);
       }
     });
     s2 = createFlicking("#stop-moveStart", {
@@ -258,7 +259,8 @@ setTimeout(function() {
       autoResize: true
     }).on({
       moveStart: function(e) {
-        e.stop()
+        e.stop();
+        console.log(e);
       }
     });
     s3 = createFlicking("#stop-move", {
@@ -266,7 +268,8 @@ setTimeout(function() {
       autoResize: true
     }).on({
       move: function(e) {
-        e.stop()
+        e.stop();
+        console.log(e);
       }
     });
     s4 = createFlicking("#stop-change", {
@@ -274,7 +277,11 @@ setTimeout(function() {
       autoResize: true
     }).on({
       change: function(e) {
-        e.stop()
+        e.stop();
+        console.log(e);
+      },
+      restore: function(e) {
+        console.log(e);
       }
     });
     s5 = createFlicking("#stop-restore", {
@@ -283,7 +290,11 @@ setTimeout(function() {
       autoResize: true
     }).on({
       restore: function(e) {
-        e.stop()
+        e.stop();
+        console.log(e);
+      },
+      change: function(e) {
+        console.log(e);
       }
     });
 

--- a/test/unit/Panel.spec.ts
+++ b/test/unit/Panel.spec.ts
@@ -28,7 +28,7 @@ describe("Panel", () => {
   const initFlicking = (type: string, options?: Partial<FlickingOptions>) => {
     flickingInfo = createFlicking(type, options);
     flicking = flickingInfo.instance;
-  }
+  };
 
   describe("next()", () => {
     it("can return correct next panel", () => {

--- a/test/unit/PanelManager.spec.ts
+++ b/test/unit/PanelManager.spec.ts
@@ -42,7 +42,7 @@ describe("PanelManager", () => {
     cameraElement.appendChild(panelElement);
 
     return new Panel(panelElement, idx, viewport);
-  }
+  };
 
   const createPanels = (count: number, baseIdx: number = 0): Panel[] => {
     const panels = new Array(count)

--- a/test/unit/events.spec.ts
+++ b/test/unit/events.spec.ts
@@ -174,7 +174,7 @@ describe("Events", () => {
     const testingEvents = [
       EVENTS.MOVE_START,
       EVENTS.MOVE,
-    ]
+    ];
 
     testingEvents.forEach(event => {
       it(`${event} can be stopped almost immediately`, () => {

--- a/test/unit/events.spec.ts
+++ b/test/unit/events.spec.ts
@@ -145,14 +145,16 @@ describe("Events", () => {
     });
     afterEach(() => {
       timer.restore();
-    })
+    });
 
     it("holdStart can be stopped almost immediately", () => {
       // Given
       let holdCount = 0;
+      const isPlayingInHoldStart: boolean[] = [];
+
       const flicking = flickingInfo.instance;
       flicking.on(EVENTS.HOLD_START, e => {
-        expect(flicking.isPlaying()).to.be.false;
+        isPlayingInHoldStart.push(flicking.isPlaying());
         holdCount += 1;
         e.stop();
       });
@@ -165,6 +167,7 @@ describe("Events", () => {
       timer.tick(500);
 
       // Then
+      expect(isPlayingInHoldStart.every(val => val === false)).to.be.true;
       expect(holdCount).equals(2);
     });
 

--- a/test/unit/events.spec.ts
+++ b/test/unit/events.spec.ts
@@ -164,7 +164,7 @@ describe("Events", () => {
       timer.tick(50);
 
       simulate(flickingInfo.element, { deltaX: -70, duration: 30 });
-      timer.tick(500);
+      timer.tick(500); // Make sure animation ends after second simulate()
 
       // Then
       expect(isPlayingInHoldStart.every(val => val === false)).to.be.true;

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -748,19 +748,19 @@ describe("Methods call", () => {
         moveType: "freeScroll",
       });
       const flicking = flickingInfo.instance;
-      const viewport = (flicking as any).viewport as Viewport;
+      const flickingViewport = (flicking as any).viewport as Viewport;
       await simulate(flickingInfo.element, {
         deltaX: -200,
         duration: 100,
       });
       await waitEvent(flicking, "moveEnd");
-      const prevCameraPosition = viewport.getCameraPosition();
+      const prevCameraPosition = flickingViewport.getCameraPosition();
 
       // When
       flicking.resize();
 
       // Then
-      const afterCameraPosition = viewport.getCameraPosition();
+      const afterCameraPosition = flickingViewport.getCameraPosition();
       expect(prevCameraPosition).equals(afterCameraPosition);
     });
   });

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -1137,10 +1137,10 @@ describe("Methods call", () => {
       // Given
       const givenLastIndex = 5;
       const flicking = flickingInfo.instance;
-      flicking.setLastIndex(givenLastIndex);
 
       // When
-      await simulate(flickingInfo.element, { deltaX: -1000, duration: 50 });
+      flicking.setLastIndex(-1);
+      flicking.setLastIndex(givenLastIndex);
 
       // Then
       expect(needPanelEvents.length).equals(1);
@@ -1151,7 +1151,7 @@ describe("Methods call", () => {
       expect(event.range.length).equals(givenLastIndex + 1);
     });
 
-    it("can still trigger events when empty panels exists where index below maximum panel count", async () => {
+    it("can still trigger events when empty panels exist where index below maximum panel count", async () => {
       // Given
       const givenLastIndex = 5;
       const flicking = flickingInfo.instance;
@@ -1161,9 +1161,10 @@ describe("Methods call", () => {
       flicking.replace(givenLastIndex, createHorizontalElement(50));
 
       // Then
-      expect(needPanelEvents.length).equals(1);
+      // This should be happened twice, after setLastIndex, and after replace
+      expect(needPanelEvents.length).equals(2);
 
-      const event = needPanelEvents[0];
+      const event = needPanelEvents[1];
       expect(event.direction).equals(DIRECTION.PREV);
       expect(event.range.min).equals(0);
       expect(event.range.max).equals(givenLastIndex - 1);
@@ -1171,9 +1172,11 @@ describe("Methods call", () => {
 
     it("can't insert more panels after lastIndex", () => {
       // Given
-      const givenLastIndex = 5;
+      flickingInfo = createFlicking(horizontal.none, {
+        infinite: true,
+        lastIndex: 5
+      });
       const flicking = flickingInfo.instance;
-      flicking.setLastIndex(givenLastIndex);
 
       // When
       const panels = counter(7).map(() => {

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -1174,7 +1174,7 @@ describe("Methods call", () => {
       // Given
       flickingInfo = createFlicking(horizontal.none, {
         infinite: true,
-        lastIndex: 5
+        lastIndex: 5,
       });
       const flicking = flickingInfo.instance;
 


### PR DESCRIPTION
## Issue
#184, #185

## Details
- This fixes #184 
- This also fixes #185

