### PR TITLE
fix: match framework rendering with native rendering

### DIFF
--- a/demo/features/infiniteflicking.html
+++ b/demo/features/infiniteflicking.html
@@ -89,9 +89,6 @@ var prev = 0;
 var next = 4;
 var flicking0 = new eg.Flicking(".flicking0", {
     gap: 10,
-    circular: true,
-    lastIndex: 10,
-    renderOnlyVisible: true,
 });
 
 document.querySelector("#prepend").addEventListener("click", function () {

--- a/demo/features/infiniteflicking.html
+++ b/demo/features/infiniteflicking.html
@@ -89,6 +89,9 @@ var prev = 0;
 var next = 4;
 var flicking0 = new eg.Flicking(".flicking0", {
     gap: 10,
+    circular: true,
+    lastIndex: 10,
+    renderOnlyVisible: true,
 });
 
 document.querySelector("#prepend").addEventListener("click", function () {

--- a/packages/react-flicking/src/demo/features/InfiniteFlicking.tsx
+++ b/packages/react-flicking/src/demo/features/InfiniteFlicking.tsx
@@ -12,8 +12,8 @@ export default class InfiniteFlicking extends React.Component<{}, { list0: numbe
     list1: [0, 1, 2, 3, 4],
     list2: [0, 1, 2, 3, 4],
   };
+
   public render() {
-    // [3, 4, 0, 1, 2, 5, 6, 7, 8]
     return (
       <div id="infinite" className="container">
         <h1>Infinite Flicking</h1>
@@ -80,6 +80,7 @@ export default class InfiniteFlicking extends React.Component<{}, { list0: numbe
       </div>
     );
   }
+
   public componentDidMount() {
     insertCode("infinite", 0, `
 <Flicking className="flicking flicking0" gap={10}>

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -158,7 +158,11 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
       }));
     }
 
-    return flicking ? flicking.mapRenderingPanels(arr) : arr;
+    if (flicking && renderOnlyVisible) {
+      arr = flicking.mapRenderingPanels(result).map(index => arr[index]);
+    }
+
+    return arr;
   }
 }
 interface Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>, FlickingType<Flicking> { }

--- a/packages/vue-flicking/demo/features/Infinite.vue
+++ b/packages/vue-flicking/demo/features/Infinite.vue
@@ -7,8 +7,8 @@
       <li>The panel's indexes are zero-based integer.</li>
       <li>Note: The number displayed above each panel is not panel's index.</li>
     </ul>
-    <flicking class="flicking flicking0" :options="{ gap: 10, renderOnlyVisible: true, circular: true, lastIndex: 10 }">
-      <div v-for="num in list0" class="infinite" :class="`panel${Math.abs(num) % 5}`" :key="`1-${num}`">
+    <flicking class="flicking flicking0" :options="{ gap: 10 }">
+      <div v-for="num in list0" class="infinite" :class="`panel${Math.abs(num) % 5}`" :key="num">
         {{ num }}
       </div>
     </flicking>
@@ -28,7 +28,7 @@
       <li>Enabling the infinite option can make <strong>needPanel</strong> event to be triggered when more panels at moving direction should be fetched within <strong>infiniteThreshold</strong> value.</li>
     </ul>
     <flicking
-      class="flicking flicking1" :options="{ gap: 10, infinite: true, infiniteThreshold: 50, renderOnlyVisible: true }"
+      class="flicking flicking1" :options="{ gap: 10, infinite: true, infiniteThreshold: 50 }"
       @need-panel="e => {
         const end = list1[list1.length - 1] || 0;
         list1.push(end + 1, end + 2);
@@ -43,7 +43,7 @@
       <li>You can make continuous carousel UI with asynchronous data by adding placeholder panel first, then update panel with fetched data later.</li>
     </ul>
     <flicking
-      class="flicking flicking2" :options="{ gap: 10, infinite: true, moveType: 'freeScroll', renderOnlyVisible: true }"
+      class="flicking flicking2" :options="{ gap: 10, infinite: true, moveType: 'freeScroll' }"
       @need-panel="() => {
         const end = list2[list2.length - 1] || 0;
         list2.push(end + 1, end + 2);

--- a/packages/vue-flicking/demo/features/Infinite.vue
+++ b/packages/vue-flicking/demo/features/Infinite.vue
@@ -7,8 +7,8 @@
       <li>The panel's indexes are zero-based integer.</li>
       <li>Note: The number displayed above each panel is not panel's index.</li>
     </ul>
-    <flicking class="flicking flicking0" :options="{ gap: 10, renderOnlyVisible: true }">
-      <div v-for="num in list0" class="infinite" :class="`panel${Math.abs(num) % 5}`" :key="num">
+    <flicking class="flicking flicking0" :options="{ gap: 10, renderOnlyVisible: true, circular: true, lastIndex: 10 }">
+      <div v-for="num in list0" class="infinite" :class="`panel${Math.abs(num) % 5}`" :key="`1-${num}`">
         {{ num }}
       </div>
     </flicking>

--- a/packages/vue-flicking/package-lock.json
+++ b/packages/vue-flicking/package-lock.json
@@ -1079,9 +1079,9 @@
       "integrity": "sha512-wSTnvqa15xsmQFVNiU0ipi6V1w6AFiDE5/QOxguk949uO4RiYPxY9QgQP3DWkmHggecp3nnjINElxXP8UM+Wtg=="
     },
     "@egjs/vue-children-differ": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@egjs/vue-children-differ/-/vue-children-differ-0.0.1.tgz",
-      "integrity": "sha512-gMaTMVuyW+IUxXLN+vnpIJ6c+DGEcogiKvxJll18Hs2g6ETeDV9Aj4MeaJyOR4NB3Gra0y3imJi8pZmLrkgDoQ==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@egjs/vue-children-differ/-/vue-children-differ-0.0.2.tgz",
+      "integrity": "sha512-Kei+BdRIzxUyaRSd47GSmqH33wCreXDeWS2vib+JuLFYPfnvAAlAsRbbY6K/wMrRVc5mBktiG7p+WKCyJ5wzbg==",
       "requires": {
         "@egjs/children-differ": "0.0.0"
       }

--- a/packages/vue-flicking/package.json
+++ b/packages/vue-flicking/package.json
@@ -32,7 +32,7 @@
  "dependencies": {
   "@egjs/flicking": "^3.2.0",
   "@egjs/list-differ": "0.0.1",
-  "@egjs/vue-children-differ": "^0.0.1",
+  "@egjs/vue-children-differ": "^0.0.2",
   "vue-property-decorator": "^8.1.0"
  },
  "devDependencies": {

--- a/packages/vue-flicking/package.json
+++ b/packages/vue-flicking/package.json
@@ -30,7 +30,7 @@
  },
  "license": "MIT",
  "dependencies": {
-  "@egjs/flicking": "^3.2.0",
+  "@egjs/flicking": "^3.4.0",
   "@egjs/list-differ": "0.0.1",
   "@egjs/vue-children-differ": "^0.0.2",
   "vue-property-decorator": "^8.1.0"

--- a/packages/vue-flicking/src/Flicking.ts
+++ b/packages/vue-flicking/src/Flicking.ts
@@ -3,7 +3,7 @@
  * egjs projects are licensed under the MIT license
  */
 
-import NativeFlicking, { Plugin, FlickingOptions, DestroyOption, withFlickingMethods, DEFAULT_OPTIONS, FlickingPanel } from "@egjs/flicking";
+import NativeFlicking, { Plugin, FlickingOptions, DestroyOption, withFlickingMethods, DEFAULT_OPTIONS } from "@egjs/flicking";
 import ChildrenDiffer from "@egjs/vue-children-differ";
 import ListDiffer, { DiffResult } from "@egjs/list-differ";
 import { Component, Vue, Prop } from "vue-property-decorator";

--- a/packages/vue-flicking/src/utils.ts
+++ b/packages/vue-flicking/src/utils.ts
@@ -1,4 +1,0 @@
-// return [0, 1, ...., max - 1]
-export function counter(max: number): number[] {
-  return [...Array(max).keys()];
-}

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -65,7 +65,7 @@ class Flicking extends Component {
   private wrapper: HTMLElement;
   private viewport: Viewport;
   private eventContext: FlickingContext;
-  private flag: boolean = false;
+  private isPanelChangedAtBeforeSync: boolean = false;
 
   /**
    * @param element A base element for the eg.Flicking module. When specifying a value as a `string` type, you must specify a css selector string to select the element.<ko>eg.Flicking 모듈을 사용할 기준 요소. `string`타입으로 값 지정시 요소를 선택하기 위한 css 선택자 문자열을 지정해야 한다.</ko>
@@ -697,7 +697,7 @@ class Flicking extends Component {
       maintained.forEach(([, next]) => { viewport.updateCheckedIndexes({ min: next, max: next }); });
     }
     panelManager.replacePanels(newPanels, newClones);
-    this.flag = true;
+    this.isPanelChangedAtBeforeSync = true;
   }
 
   /**
@@ -751,9 +751,9 @@ class Flicking extends Component {
       // As it can be 0
       beforePanel.unCacheBbox();
     });
-    if (this.flag) {
+    if (this.isPanelChangedAtBeforeSync) {
       viewport.resetVisibleIndex();
-      this.flag = false;
+      this.isPanelChangedAtBeforeSync = false;
     }
     viewport.resize();
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -401,7 +401,7 @@ class Panel implements FlickingPanel {
     const viewport = this.viewport;
     let cloneElement = element;
 
-    if (!cloneElement && this.element) {
+    if (!cloneElement && this.element && viewport.options.renderOnlyVisible) {
       cloneElement = isVirtual ? this.element : this.element.cloneNode(true) as HTMLElement;
     }
     const clonedPanel = new Panel(cloneElement, state.index, viewport);
@@ -468,15 +468,18 @@ class Panel implements FlickingPanel {
       this.state.originalStyle.className = element.getAttribute("class");
       this.state.originalStyle.style = element.getAttribute("style");
     }
-    this.element = element;
 
-    const options = this.viewport.options;
-    if (options.classPrefix) {
-      addClass(element, `${options.classPrefix}-panel`);
+    if (element !== this.element) {
+      this.element = element;
+
+      const options = this.viewport.options;
+      if (options.classPrefix) {
+        addClass(element, `${options.classPrefix}-panel`);
+      }
+
+      // Update size info after applying panel css
+      applyCSS(this.element, DEFAULT_PANEL_CSS);
     }
-
-    // Update size info after applying panel css
-    applyCSS(this.element, DEFAULT_PANEL_CSS);
   }
 }
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -407,7 +407,7 @@ class Panel implements FlickingPanel {
     const viewport = this.viewport;
     let cloneElement = element;
 
-    if (!cloneElement && this.element && viewport.options.renderOnlyVisible) {
+    if (!cloneElement && this.element) {
       cloneElement = isVirtual ? this.element : this.element.cloneNode(true) as HTMLElement;
     }
     const clonedPanel = new Panel(cloneElement, state.index, viewport);

--- a/src/components/PanelManager.ts
+++ b/src/components/PanelManager.ts
@@ -205,6 +205,13 @@ class PanelManager {
 
     if (isCircular) {
       this.addNewClones(index, newPanels, newPanels.length - pushedIndex, nextSibling);
+      const clones = this.clones;
+      const panelCount = this.panels.length;
+      if (clones[0] && clones[0].length > lastIndex + 1) {
+        clones.forEach(cloneSet => {
+          cloneSet.splice(panelCount);
+        });
+      }
     }
 
     return pushedIndex;

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -185,8 +185,12 @@ export default class Viewport {
     const state = this.state;
     const options = this.options;
     const transform = state.translate.name;
+    const scrollArea = state.scrollArea;
 
     // Update position & nearestPanel
+    if (!isBetween(pos, scrollArea.prev, scrollArea.next)) {
+      pos = circulate(pos, scrollArea.prev, scrollArea.next, false);
+    }
     state.position = pos;
     this.nearestPanel = this.findNearestPanel();
     const nearestPanel = this.nearestPanel;
@@ -258,13 +262,6 @@ export default class Viewport {
     }
     state.isAdaptiveCached = false;
     this.panelBboxes = {};
-  }
-
-  public beforeSync(): void {
-    this.updateOriginalPanelPositions();
-    this.updateClonePanels();
-    // update visible index
-    this.updateVisiblePanels();
   }
 
   public resize(): void {
@@ -1885,7 +1882,9 @@ export default class Viewport {
 
     const newVisibleIndex = {
       // Relative index including clone, can be negative number
-      min: lastPanelOfPrevDir.getIndex() - minPanelCloneOffset,
+      min: basePanel.getCloneIndex() > -1
+        ? lastPanelOfPrevDir.getIndex() + minPanelCloneOffset
+        : lastPanelOfPrevDir.getIndex() - minPanelCloneOffset,
       // Relative index including clone
       max: lastPanelOfNextDir.getIndex() + maxPanelCloneOffset,
     };

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -992,11 +992,15 @@ export default class Viewport {
       panels.forEach(panel => {
         const overlappedClass = panel.getOverlappedClass(equalSizeClasses);
         if (overlappedClass && !cached[overlappedClass]) {
-          fragment.appendChild(panel.getElement());
+          if (!options.renderExternal) {
+            fragment.appendChild(panel.getElement());
+          }
           this.visiblePanels.push(panel);
           cached[overlappedClass] = true;
         } else if (!overlappedClass) {
-          fragment.appendChild(panel.getElement());
+          if (!options.renderExternal) {
+            fragment.appendChild(panel.getElement());
+          }
           this.visiblePanels.push(panel);
         }
       });
@@ -1004,7 +1008,9 @@ export default class Viewport {
         this.addVisiblePanel(panel);
       });
     } else {
-      panels.forEach(panel => fragment.appendChild(panel.getElement()));
+      if (!options.renderExternal) {
+        panels.forEach(panel => fragment.appendChild(panel.getElement()));
+      }
       this.visiblePanels = panels.filter(panel => Boolean(panel));
     }
 
@@ -1808,6 +1814,8 @@ export default class Viewport {
           max: newVisibleIndex.max,
         },
       });
+    } else {
+      this.visiblePanels.forEach(panel => panel.setPositionCSS(state.positionOffset));
     }
   }
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -126,7 +126,6 @@ export const FLICKING_METHODS: {[key in FlickingMethodsKeys]: true} = {
   getPanelCount: true,
   getStatus: true,
   getVisiblePanels: true,
-  getVisibleIndex: true,
   setLastIndex: true,
   enableInput: true,
   disableInput: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -492,7 +492,7 @@ export interface Plugin {
 
 export type ExcludeKeys = keyof Component
   | "replace" | "append" | "remove" | "prepend"
-  | "beforeSync" | "sync" | "getCloneCount" | "mapRenderingPanels";
+  | "beforeSync" | "sync" | "getCloneCount" | "getRenderingIndexes";
 export type FlickingMethodsKeys = Exclude<keyof Flicking, ExcludeKeys>;
 export type FlickingMethods = Pick<Flicking, FlickingMethodsKeys>;
 

--- a/test/unit/events.spec.ts
+++ b/test/unit/events.spec.ts
@@ -426,6 +426,7 @@ describe("Events", () => {
       expect(halfProgress).to.be.equals(0.5);
       expect(fullProgress).to.be.equals(1);
     });
+
     it("Check the progress of the 'move' event.(circular: true)", async () => {
       flickingInfo = createFlicking(horizontal.full, { defaultIndex: 0, circular: true });
       let progress = 0;

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -1382,7 +1382,7 @@ describe("Methods call", () => {
   });
 
   describe("beforeSync() with renderOnlyVisible", () => {
-    it("can add element with beforeSync, renderOnlyVisible", () => {
+    it("can add panel with beforeSync, renderOnlyVisible", () => {
       // Given
       // 30, 30, 30, 30, 30, 30
       flickingInfo = createFlicking(horizontal.panel30, {
@@ -1399,16 +1399,10 @@ describe("Methods call", () => {
 
       // When
       flicking.beforeSync(result);
-      // 0, DIV, 1, 2
-      const visibleElements = flicking.getVisiblePanels().map(panel => panel.getElement());
 
       // Then
-      expect(visibleElements).to.be.deep.equals([
-        nextElements[0],
-        undefined,
-        nextElements[2],
-        nextElements[3],
-      ]);
+      expect(flicking.getPanelCount()).equals(7);
+      expect(flicking.getPanel(1).getElement()).to.be.undefined;
     });
 
     it("can remove element with beforeSync, renderOnlyVisible", () => {
@@ -1428,16 +1422,12 @@ describe("Methods call", () => {
       const result = diff(allElements, nextElements);
 
       // When
+      const removingPanel = flicking.getPanel(1);
       flicking.beforeSync(result);
-      // 0, 2, 3
-      const visibleElements = flicking.getVisiblePanels().map(panel => panel.getElement());
 
       // Then
-      expect(visibleElements).to.be.deep.equals([
-        allElements[0],
-        allElements[2],
-        allElements[3],
-      ]);
+      expect(flicking.getPanelCount()).equals(5);
+      expect(flicking.getAllPanels().every(panel => panel !== removingPanel));
     });
   });
 


### PR DESCRIPTION
## Issue
#273

## Details
This PR is made to match the rendering method same with native's.
That is, when a new panel threw in, the framework should render new panels with visible ones to calculate size.
This also implements `isEqualSize` and `isConstantSize` options for framework Flickings.
The real implementation is only available for only Vue-Flicking yet.