### PR TITLE
fix: adaptive options not works after #334

### DIFF
--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -590,10 +590,12 @@ export default class Viewport {
         sizeToApply = maximumPanelSize;
       }
 
-      const viewportBbox = this.updateBbox();
-      sizeToApply = Math.max(sizeToApply, horizontal ? viewportBbox.height : viewportBbox.width);
+      if (!state.isAdaptiveCached) {
+        const viewportBbox = this.updateBbox();
+        sizeToApply = Math.max(sizeToApply, horizontal ? viewportBbox.height : viewportBbox.width);
+        state.isAdaptiveCached = true;
+      }
 
-      state.isAdaptiveCached = true;
       const viewportSize = `${sizeToApply}px`;
       if (horizontal) {
         viewportStyle.height = viewportSize;

--- a/test/manual/html/resize.html
+++ b/test/manual/html/resize.html
@@ -11,7 +11,6 @@
     <script src="../../../dist/flicking.pkgd.js"></script>
 </head>
 <body class="container" style="display: none;">
-    <asdf>
     <section class="hero">
         <div class="hero-body">
             <h1 class="title">
@@ -52,7 +51,6 @@
             <p>Layer 1</p>
         </div>
     </div>
-    </asdf>
 
     <script src="../js/common.js"></script>
     <script src="../js/resize.js"></script>

--- a/test/unit/assets/fixture.ts
+++ b/test/unit/assets/fixture.ts
@@ -128,6 +128,14 @@ export const horizontal = {
       ),
     ),
   ),
+  hasDifferentHeight: wrapper(
+    viewport(
+      camera(
+        [panel, "panel-horizontal-full"],
+        [panel, "panel-horizontal-full panel-vertical-2000px"],
+      ),
+    ),
+  ),
 };
 
 export const vertical = {

--- a/test/unit/options.spec.ts
+++ b/test/unit/options.spec.ts
@@ -1255,4 +1255,50 @@ describe("Initialization", () => {
       expect(prevSize).equals(afterSize);
     });
   });
+
+  describe("adaptive", () => {
+    it("should current panel height at init", () => {
+      // Given & When
+      flickingInfo = createFlicking(horizontal.hasDifferentHeight, {
+        adaptive: true,
+      });
+
+      // Then
+      const flicking = flickingInfo.instance;
+      const viewportEl = flickingInfo.element.querySelector(".eg-flick-viewport") as HTMLElement;
+      const firstPanelEl = flicking.getPanel(0).getElement();
+      const secondPanelEl = flicking.getPanel(1).getElement();
+      const viewportSize = viewportEl.getBoundingClientRect().height;
+      const firstPanelSize = firstPanelEl.getBoundingClientRect().height;
+      const secondPanelSize = secondPanelEl.getBoundingClientRect().height;
+      expect(viewportSize).equals(firstPanelSize);
+      expect(secondPanelSize).greaterThan(firstPanelSize);
+    });
+
+    it("should change viewport height to current panel's height", async () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.hasDifferentHeight, {
+        adaptive: true,
+      });
+      const flicking = flickingInfo.instance;
+      const viewportEl = flickingInfo.element.querySelector(".eg-flick-viewport") as HTMLElement;
+      const firstPanelEl = flicking.getPanel(0).getElement();
+      const secondPanelEl = flicking.getPanel(1).getElement();
+      const firstPanelSize = firstPanelEl.getBoundingClientRect().height;
+      const secondPanelSize = secondPanelEl.getBoundingClientRect().height;
+
+      // When
+      const heightInit = viewportEl.getBoundingClientRect().height;
+      flicking.moveTo(1, 300);
+      tick(500);
+      const heightAtPanel1 = viewportEl.getBoundingClientRect().height;
+      flicking.moveTo(0, 0);
+      const heightAtPanel0 = viewportEl.getBoundingClientRect().height;
+
+      // Then
+      expect(heightInit).equals(firstPanelSize);
+      expect(heightAtPanel1).equals(secondPanelSize);
+      expect(heightAtPanel0).equals(firstPanelSize);
+    });
+  });
 });


### PR DESCRIPTION
## Issue
#333, #334

## Details
Height resizing with adaptive option does not work after #318.
I've fixed that bug & added some test codes for the adaptive option.
