### PR TITLE
feat: add viewportTag and cameraTag to frameworks

### DIFF
--- a/packages/react-flicking/README.md
+++ b/packages/react-flicking/README.md
@@ -45,6 +45,8 @@ import { Parallax, Fade, AutoPlay } from "@egjs/flicking-plugins";
 
 <Flicking
   tag = "div"
+  viewportTag = "div"
+  cameraTag = "div"
   onNeedPanel = {(e: NeedPanelEvent) => {}}
   onMoveStart = {(e: FlickingEvent) => {}}
   onMove = {(e: FlickingEvent) => {}}

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -39,8 +39,11 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
 
   public render() {
     const props = this.props;
-    // tslint:disable-next-line:naming-convention
+    /* tslint:disable:naming-convention */
     const Tag = props.tag as any;
+    const Viewport = props.viewportTag as any;
+    const Camera = props.cameraTag as any;
+    /* tslint:enable:naming-convention */
     const classPrefix = props.classPrefix;
     const attributes: { [key: string]: any } = {};
 
@@ -51,13 +54,13 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     }
     return (
       <Tag {...attributes}>
-        <div className={`${classPrefix}-viewport`}>
-          <div className={`${classPrefix}-camera`}>
+        <Viewport className={`${classPrefix}-viewport`}>
+          <Camera className={`${classPrefix}-camera`}>
             <ChildrenDiffer onUpdate={this.onUpdate}>
               {this.renderPanels()}
             </ChildrenDiffer>
-          </div>
-        </div>
+          </Camera>
+        </Viewport>
       </Tag>
     );
   }

--- a/packages/react-flicking/src/react-flicking/consts.ts
+++ b/packages/react-flicking/src/react-flicking/consts.ts
@@ -3,6 +3,8 @@ import { FlickingProps } from "./types";
 
 export const FLICKING_PROPS: FlickingProps = {
   tag: "div",
+  viewportTag: "div",
+  cameraTag: "div",
   classPrefix: "eg-flick",
   plugins: [],
   onNeedPanel: (e: NeedPanelEvent) => {},

--- a/packages/react-flicking/src/react-flicking/types.ts
+++ b/packages/react-flicking/src/react-flicking/types.ts
@@ -10,6 +10,8 @@ export type FlickingType<T> = {
 
 export interface FlickingProps {
   tag: keyof JSX.IntrinsicElements;
+  viewportTag: keyof JSX.IntrinsicElements;
+  cameraTag: keyof JSX.IntrinsicElements;
   status?: FlickingStatus;
   plugins: Plugin[];
   onHoldStart: (e: FlickingEvent) => any;

--- a/packages/vue-flicking/README.md
+++ b/packages/vue-flicking/README.md
@@ -67,6 +67,8 @@ export default {
   <flicking
     :options="{ gap: 10, moveType: 'freeScroll' }"
     :tag="'div'"
+    :viewportTag="'div'"
+    :cameraTag="'div'"
     :plugins="plugins"
     @need-panel="e => {
       // ADD PANELS

--- a/packages/vue-flicking/src/Flicking.ts
+++ b/packages/vue-flicking/src/Flicking.ts
@@ -16,8 +16,12 @@ import { FlickingType } from "./types";
   },
 })
 class Flicking extends Vue {
-  // Tag of wrapper element
+  // Tag of the wrapper element
   @Prop({ type: String, default: "div", required: false }) tag!: string;
+  // Tag of the viewport element
+  @Prop({ type: String, default: "div", required: false }) viewportTag!: string;
+  // Tag of the camera element
+  @Prop({ type: String, default: "div", required: false }) cameraTag!: string;
   @Prop({ type: Object, default: () => ({}), required: false }) options!: Partial<FlickingOptions>;
   @Prop({ type: Array, default: () => ([]), required: false }) plugins!: Plugin[];
 
@@ -81,8 +85,8 @@ class Flicking extends Vue {
     const panels = this.$_getPanels(h);
 
     return h(this.tag,
-      [h("div", viewportData,
-        [h("div", cameraData,
+      [h(this.viewportTag, viewportData,
+        [h(this.cameraTag, cameraData,
           panels,
         )],
       )],


### PR DESCRIPTION
## Issue
#339 

## Details
This adds 2 following new props to the Flicking component of React & Vue.
- viewportTag: set the tag name of the viewport element(`eg-flick-viewport`)
- cameraTag: set the tag name of the camera element(`eg-flick-camera`)
This closes #339
