### PR TITLE
fix: wrong camera position after resizing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@egjs/flicking",
-	"version": "3.5.0",
+	"version": "3.5.0-snapshot",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/components/Viewport.ts
+++ b/src/components/Viewport.ts
@@ -588,6 +588,7 @@ export default class Viewport {
   public updateCameraPosition(): void {
     const state = this.state;
     const currentPanel = this.getCurrentPanel();
+    const cameraPosition = this.getCameraPosition();
     const currentState = this.stateMachine.getState();
     const isFreeScroll = this.moveType.is(MOVE_TYPE.FREE_SCROLL);
     const relativeHangerPosition = this.getRelativeHangerPosition();
@@ -600,15 +601,17 @@ export default class Viewport {
 
     let newPosition: number;
     if (isFreeScroll) {
+      const positionBounded = this.canSetBoundMode() && (cameraPosition === state.scrollArea.prev || cameraPosition === state.scrollArea.next);
       const nearestPanel = this.getNearestPanel();
 
-      newPosition = nearestPanel
-        ? nearestPanel.getPosition() - halfGap + (nearestPanel.getSize() + 2 * halfGap) * state.panelMaintainRatio - relativeHangerPosition
-        : this.getCameraPosition();
+      // Preserve camera position if it is bound to scroll area limit
+      newPosition = positionBounded || !nearestPanel
+        ? cameraPosition
+        : nearestPanel.getPosition() - halfGap + (nearestPanel.getSize() + 2 * halfGap) * state.panelMaintainRatio - relativeHangerPosition;
     } else {
       newPosition = currentPanel
         ? currentPanel.getAnchorPosition() - relativeHangerPosition
-        : this.getCameraPosition();
+        : cameraPosition;
     }
 
     if (this.canSetBoundMode()) {

--- a/test/manual/html/default.html
+++ b/test/manual/html/default.html
@@ -136,6 +136,22 @@
         </div>
     </div>
 
+    <p class="subtitle is-4">Width: 0</p>
+    <div id="flick1-7" class="is-mobile is-size-7-mobile">
+        <div class="has-background-primary" style="width: 0; height: 0;">
+            <p>Layer 0</p>
+        </div>
+        <div class="has-background-danger" style="width: 0; height: 0;">
+            <p>Layer 1</p>
+        </div>
+        <div class="has-background-info" style="width: 0; height: 0;">
+            <p>Layer 2</p>
+        </div>
+        <div class="has-background-success" style="width: 0; height: 0;">
+            <p>Layer 3</p>
+        </div>
+    </div>
+
     <script src="../js/common.js"></script>
     <script src="../js/default.js"></script>
 </body>

--- a/test/manual/js/default.js
+++ b/test/manual/js/default.js
@@ -34,4 +34,7 @@ setTimeout(function() {
         gap: 100,
         autoResize: true
     });
+    f1g = createFlicking("#flick1-7", {
+        autoResize: true
+    });
 }, 500);

--- a/test/unit/assets/fixture.css
+++ b/test/unit/assets/fixture.css
@@ -20,6 +20,8 @@ p {
 .panel-horizontal-40 { width: 40% }
 .panel-horizontal-50 { width: 50% }
 .panel-horizontal-100px { width: 100px }
+.panel-horizontal-0px { width: 0px }
+.panel-horizontal-none { display: none; }
 
 .panel-vertical-full { height: 100% }
 .panel-vertical-10 { height: 10% }

--- a/test/unit/assets/fixture.ts
+++ b/test/unit/assets/fixture.ts
@@ -136,6 +136,24 @@ export const horizontal = {
       ),
     ),
   ),
+  hasZeroWidth: wrapper(
+    viewport(
+      camera(
+        [panel, "panel-horizontal-0px"],
+        [panel, "panel-horizontal-0px"],
+        [panel, "panel-horizontal-0px"],
+      ),
+    ),
+  ),
+  hasDisplayNone: wrapper(
+    viewport(
+      camera(
+        [panel, "panel-horizontal-none"],
+        [panel, "panel-horizontal-none"],
+        [panel, "panel-horizontal-none"],
+      ),
+    ),
+  ),
 };
 
 export const vertical = {

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -809,6 +809,114 @@ describe("Methods call", () => {
       // Then
       expect(window.scrollY).equals(1000); // Should not be scrolled to top(0)
     });
+
+    it("shouldn't be scrolled if second panel is selected and freescroll & bound option is enabled (#376)", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.panel30N(10), {
+        moveType: "freeScroll",
+        bound: true,
+      });
+
+      // When
+      const flicking = flickingInfo.instance;
+      const viewport = (flicking as any).viewport;
+      const origCameraPos = viewport.getCameraPosition();
+      flicking.moveTo(1, 0);
+      const boundCameraPos = viewport.getCameraPosition();
+      flicking.resize();
+
+      // Then
+      const resizeCameraPos = viewport.getCameraPosition();
+      expect(origCameraPos).equals(boundCameraPos);
+      expect(origCameraPos).equals(resizeCameraPos);
+    });
+
+    it("shouldn't be scrolled if second to last panel is selected and freescroll & bound option is enabled (#376)", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.panel30N(10), {
+        moveType: "freeScroll",
+        bound: true,
+      });
+
+      // When
+      const flicking = flickingInfo.instance;
+      const viewport = (flicking as any).viewport;
+      flicking.moveTo(9, 0);
+      const origCameraPos = viewport.getCameraPosition();
+      flicking.moveTo(8, 0);
+      const boundCameraPos = viewport.getCameraPosition();
+      flicking.resize();
+
+      // Then
+      const resizeCameraPos = viewport.getCameraPosition();
+      expect(origCameraPos).equals(boundCameraPos);
+      expect(origCameraPos).equals(resizeCameraPos);
+    });
+
+    it("should be scrolled if panel is prepended and freescroll & bound option is enabled (#376)", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.panel30N(10), {
+        moveType: "freeScroll",
+        bound: true,
+      });
+
+      // When
+      const flicking = flickingInfo.instance;
+      const viewport = (flicking as any).viewport;
+      const origCameraPos = viewport.getCameraPosition();
+      flicking.moveTo(1, 0);
+      const boundCameraPos = viewport.getCameraPosition();
+      flicking.prepend(horizontal.fullN(1));
+
+      // Then
+      const resizeCameraPos = viewport.getCameraPosition();
+      expect(origCameraPos).equals(boundCameraPos);
+      expect(origCameraPos).not.equals(resizeCameraPos);
+      expect(boundCameraPos).not.equals(resizeCameraPos);
+    });
+
+    it("should be scrolled if second panel is selected and freescroll is enabled (#376)", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.panel30N(10), {
+        moveType: "freeScroll",
+      });
+
+      // When
+      const flicking = flickingInfo.instance;
+      const viewport = (flicking as any).viewport;
+      const origCameraPos = viewport.getCameraPosition();
+      flicking.moveTo(1, 0);
+      const movedCameraPos = viewport.getCameraPosition();
+      flicking.resize();
+
+      // Then
+      const resizeCameraPos = viewport.getCameraPosition();
+      expect(origCameraPos).not.equals(movedCameraPos);
+      expect(origCameraPos).not.equals(resizeCameraPos);
+      expect(movedCameraPos).equals(resizeCameraPos);
+    });
+
+    it("should be scrolled if second to last panel is selected and freescroll is enabled (#376)", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.panel30N(10), {
+        moveType: "freeScroll",
+      });
+
+      // When
+      const flicking = flickingInfo.instance;
+      const viewport = (flicking as any).viewport;
+      flicking.moveTo(9, 0);
+      const origCameraPos = viewport.getCameraPosition();
+      flicking.moveTo(8, 0);
+      const movedCameraPos = viewport.getCameraPosition();
+      flicking.resize();
+
+      // Then
+      const resizeCameraPos = viewport.getCameraPosition();
+      expect(origCameraPos).not.equals(movedCameraPos);
+      expect(origCameraPos).not.equals(resizeCameraPos);
+      expect(movedCameraPos).equals(resizeCameraPos);
+    });
   });
 
   describe("getStatus()", () => {

--- a/test/unit/options.spec.ts
+++ b/test/unit/options.spec.ts
@@ -138,6 +138,20 @@ describe("Initialization", () => {
     //   // Then
     //   expect(mockGa.callCount).to.be.equals(1);
     // });
+
+    it("won't throw error even if all panel has width: 0", () => {
+      // Given & When
+      expect(() => {
+        flickingInfo = createFlicking(horizontal.hasZeroWidth);
+      }).not.to.throw();
+    });
+
+    it("won't throw error even if all panel has display: none", () => {
+      // Given & When
+      expect(() => {
+        flickingInfo = createFlicking(horizontal.hasDisplayNone);
+      }).not.to.throw();
+    });
   });
 
   describe("circular", () => {


### PR DESCRIPTION
## Issue
#376

## Details
This fixes #376
This also adds test cases for when all panels have 0 widths.
