### PR TITLE
fix: wrong rendering indexes with renderOnlyVisible: true & circular: true

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -624,9 +624,9 @@ class Flicking extends Component<{
 
   /**
    * Get indexes to render. Should be used with `renderOnlyVisible` option.
-   * `beforeSync` should be called before this method for a correct result
+   * `beforeSync` should be called before this method for a correct result.
    * @private
-   * @ko 렌더링이 필요한 인덱스들을 반환한다. `renderOnlyVisible` 옵션과 함께 사용해야 한다.
+   * @ko 렌더링이 필요한 인덱스들을 반환한다. `renderOnlyVisible` 옵션과 함께 사용해야 한다. 정확한 결과를 위해선 `beforeSync`를 이전에 호출해야만 합니다.
    * @param - Info object of how panel infos are changed.<ko>패널 정보들의 변경 정보를 담는 오브젝트.</ko>
    * @return Array of indexes to render.<ko>렌더링할 인덱스의 배열</ko>
    */
@@ -634,11 +634,10 @@ class Flicking extends Component<{
     const viewport = this.viewport;
     const visiblePanels = viewport.getVisiblePanels();
     const maintained = diffResult.maintained.reduce((values: {[key: number]: number}, [before, after]) => {
-      values[before] = after;
+      values[after] = before;
       return values;
     }, {});
 
-    const prevPanelCount = diffResult.prevList.length;
     const panelCount = diffResult.list.length;
     const added = diffResult.added;
     const getPanelAbsIndex = (panel: Panel) => {
@@ -646,7 +645,7 @@ class Flicking extends Component<{
     };
 
     const visibleIndexes = visiblePanels.map(panel => getPanelAbsIndex(panel))
-      .filter(val => maintained[val % prevPanelCount] != null);
+      .filter(val => maintained[val % panelCount] != null);
 
     const renderingPanels = [...visibleIndexes, ...added];
     const allPanels = viewport.panelManager.allPanels();

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -624,6 +624,7 @@ class Flicking extends Component<{
 
   /**
    * Get indexes to render. Should be used with `renderOnlyVisible` option.
+   * `beforeSync` should be called before this method for a correct result
    * @private
    * @ko 렌더링이 필요한 인덱스들을 반환한다. `renderOnlyVisible` 옵션과 함께 사용해야 한다.
    * @param - Info object of how panel infos are changed.<ko>패널 정보들의 변경 정보를 담는 오브젝트.</ko>
@@ -631,7 +632,6 @@ class Flicking extends Component<{
    */
   public getRenderingIndexes(diffResult: DiffResult<any>): number[] {
     const viewport = this.viewport;
-    const isCircular = this.options.circular;
     const visiblePanels = viewport.getVisiblePanels();
     const maintained = diffResult.maintained.reduce((values: {[key: number]: number}, [before, after]) => {
       values[before] = after;
@@ -642,20 +642,11 @@ class Flicking extends Component<{
     const panelCount = diffResult.list.length;
     const added = diffResult.added;
     const getPanelAbsIndex = (panel: Panel) => {
-      return panel.getIndex() + (panel.getCloneIndex() + 1) * prevPanelCount;
+      return panel.getIndex() + (panel.getCloneIndex() + 1) * panelCount;
     };
 
-    let visibleIndexes = visiblePanels.map(panel => getPanelAbsIndex(panel));
-    visibleIndexes = visibleIndexes
-      .filter(val => maintained[val % prevPanelCount] != null)
-      .map(val => {
-        const cloneIndex = Math.floor(val / prevPanelCount);
-        const changedIndex = maintained[val % prevPanelCount];
-
-        return isCircular
-          ? changedIndex + panelCount * cloneIndex
-          : changedIndex;
-      });
+    const visibleIndexes = visiblePanels.map(panel => getPanelAbsIndex(panel))
+      .filter(val => maintained[val % prevPanelCount] != null);
 
     const renderingPanels = [...visibleIndexes, ...added];
     const allPanels = viewport.panelManager.allPanels();

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -1387,12 +1387,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: false,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [0, 1, 2, 3, 4, 5];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       expect(renderingIndexes).to.be.deep.equals([0, 1, 2]);
@@ -1404,12 +1407,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: true,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [0, 1, 2, 3, 4, 5];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       // It is rendered [10, 11, 0, 1, 2]
@@ -1423,12 +1429,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: false,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [0, 1, 2, 3, 4, 5, 6, 7];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       // Render previously rendered(0, 1, 2) + new ones(6, 7)
@@ -1441,12 +1450,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: true,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [0, 1, 2, 3, 4, 5, 6, 7];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       // It should return in order of
@@ -1462,12 +1474,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: false,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [-2, -1, 0, 1, 2, 3, 4, 5];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       // It should return
@@ -1482,12 +1497,15 @@ describe("Methods call", () => {
         renderOnlyVisible: true,
         circular: true,
       });
+      const flicking = flickingInfo.instance;
 
       // When
       const prevItems = [0, 1, 2, 3, 4, 5];
       const newItems = [-2, -1, 0, 1, 2, 3, 4, 5];
       const result = diff(prevItems, newItems);
-      const renderingIndexes = flickingInfo.instance.getRenderingIndexes(result);
+
+      flicking.beforeSync(result);
+      const renderingIndexes = flicking.getRenderingIndexes(result);
 
       // Then
       // It should return


### PR DESCRIPTION
## Issue
#389

## Details
This fixes the additional issue of #389 that adding `circular: true` option can reproduce the issue.
