### PR TITLE
feat: add getSize

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -307,6 +307,15 @@ class Flicking extends Component<{
   }
 
   /**
+   * Return the viewport element's size.
+   * @ko 뷰포트 엘리먼트의 크기를 반환한다.
+   * @return Width if horizontal: true, height if horizontal: false
+   */
+  public getSize(): number {
+    return this.viewport.getSize();
+  }
+
+  /**
    * Return current panel. `null` if no panel exists.
    * @ko 현재 패널을 반환한다. 패널이 하나도 없을 경우 `null`을 반환한다.
    * @return Current panel.<ko>현재 패널.</ko>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -125,6 +125,7 @@ export const FLICKING_METHODS: {[key in FlickingMethodsKeys]: true} = {
   getAllPanels: true,
   getCurrentPanel: true,
   getElement: true,
+  getSize: true,
   getPanel: true,
   getPanelCount: true,
   getStatus: true,

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -2,7 +2,7 @@ import { spy } from "sinon";
 
 import Flicking from "../../src/Flicking";
 import { FlickingEvent, FlickingPanel, NeedPanelEvent } from "../../src/types";
-import { horizontal, panel as createPanelElement } from "./assets/fixture";
+import { horizontal, panel as createPanelElement, vertical } from "./assets/fixture";
 import { createFlicking, cleanup, simulate, createHorizontalElement, tick, createFixture } from "./assets/utils";
 import { EVENTS, DIRECTION } from "../../src/consts";
 import { counter, toArray } from "../../src/utils";
@@ -1838,6 +1838,36 @@ describe("Methods call", () => {
           expect(panel.getElement().classList.contains(panelClassName)).to.be.true;
         });
       });
+    });
+  });
+
+  describe("getSize()", () => {
+    it("should return width if horizontal:true", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.full, { horizontal: true });
+      const flicking = flickingInfo.instance;
+      const wrapper = flicking.getElement();
+      const viewportEl = wrapper.querySelector(".eg-flick-viewport");
+
+      // When
+      const size = flicking.getSize();
+
+      // Then
+      expect(size).equals(viewportEl.getBoundingClientRect().width);
+    });
+
+    it("should return height if horizontal:false", () => {
+      // Given
+      flickingInfo = createFlicking(vertical.full, { horizontal: false });
+      const flicking = flickingInfo.instance;
+      const wrapper = flicking.getElement();
+      const viewportEl = wrapper.querySelector(".eg-flick-viewport");
+
+      // When
+      const size = flicking.getSize();
+
+      // Then
+      expect(size).equals(viewportEl.getBoundingClientRect().height);
     });
   });
 });


### PR DESCRIPTION
## Issue
#401 

## Details
This adds a new method for Flicking, `getSize()` which returns the size of the viewport
