### PR TITLE
fix: only call getCloneCount function when it exists

### DIFF
--- a/packages/ngx-flicking/projects/ngx-flicking/src/lib/ngx-flicking.component.ts
+++ b/packages/ngx-flicking/projects/ngx-flicking/src/lib/ngx-flicking.component.ts
@@ -181,7 +181,7 @@ export class NgxFlickingComponent extends FlickingInterface
   }
 
   checkCloneCount() {
-    if (!this.flicking) {
+    if (!this.flicking || typeof(this.flicking.getCloneCount) !== 'function') {
       return;
     }
 


### PR DESCRIPTION
## Details
We've been getting errors on our website reported in New Relic:
```
this.flicking.getCloneCount is not a function:
183 | checkCloneCount() {
184 | if (!this.flicking) {
185 | return;
186 | }
187 |  
188 | const newCC = this.flicking.getCloneCount();
189 |  
190 | if (this.internalCloneCount === newCC) {
191 | return;
192 | }
```

This fix checks to make sure that the function actually exists.