### PR TITLE
fix: resize throws error when there're empty panels

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -532,7 +532,9 @@ class Flicking extends Component<{
 
     const allPanels = viewport.panelManager.allPanels();
     if (!options.isConstantSize) {
-      allPanels.forEach(panel => panel.unCacheBbox());
+      allPanels
+        .filter(panel => !!panel)
+        .forEach(panel => panel.unCacheBbox());
     }
 
     const shouldResetElements = options.renderOnlyVisible

--- a/src/components/PanelManager.ts
+++ b/src/components/PanelManager.ts
@@ -242,7 +242,6 @@ class PanelManager {
       // Temporarily insert null at index to use splice()
       (panels[index] as any) = null;
     }
-
     const replacedPanels = panels.splice(index, newPanels.length, ...newPanels);
     const wasNonEmptyCount = replacedPanels.filter(panel => Boolean(panel)).length;
 

--- a/test/manual/html/resize.html
+++ b/test/manual/html/resize.html
@@ -52,6 +52,19 @@
         </div>
     </div>
 
+    <p class="subtitle is-4">Empty panels between, should not throw error</p>
+    <div id="flick4" class="columns is-mobile is-size-7-mobile">
+        <div class="column is-full has-background-primary">
+            <p>Layer 0</p>
+        </div>
+        <div class="column is-full has-background-danger">
+            <p>Layer 1</p>
+        </div>
+        <div class="column is-full has-background-info">
+            <p>Layer 2</p>
+        </div>
+    </div>
+
     <script src="../js/common.js"></script>
     <script src="../js/resize.js"></script>
 </body>

--- a/test/manual/js/resize.js
+++ b/test/manual/js/resize.js
@@ -22,4 +22,10 @@ setTimeout(function() {
         gap: 50,
         autoResize: true
     });
+
+    f4 = createFlicking("#flick4", {
+      autoResize: true
+    });
+
+    f4.replace(10, createPanelElement(0));
 }, 500);

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -949,6 +949,18 @@ describe("Methods call", () => {
       expect(origCameraPos).not.equals(resizeCameraPos);
       expect(movedCameraPos).equals(resizeCameraPos);
     });
+
+    it("should not throw error when there're empty panels between", () => {
+      // Given
+      flickingInfo = createFlicking(horizontal.full);
+
+      // When
+      const flicking = flickingInfo.instance;
+      flicking.replace(10, "<div><p></p></div>");
+
+      // Then
+      expect(() => flicking.resize()).not.throws;
+    });
   });
 
   describe("getStatus()", () => {


### PR DESCRIPTION
## Details
This fixes issue that resize throws an error when there're empty panels between solid panels.
