### PR TITLE
fix: missing resize in withFlickingMethods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,6 +145,7 @@ module.exports = {
         "@typescript-eslint/prefer-namespace-keyword": "error",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/restrict-template-expressions": "off",
+        "@typescript-eslint/unbound-method": "off",
         "@typescript-eslint/quotes": [
           "error",
           "double"

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -622,6 +622,8 @@ class Flicking extends Component<FlickingEvents> {
     this._camera = this._createCamera();
     this._control = this._createControl();
 
+    this.resize = this.resize.bind(this);
+
     if (this._autoInit) {
       void this.init();
     }
@@ -1012,7 +1014,7 @@ class Flicking extends Component<FlickingEvents> {
    * @fires Flicking#afterResize
    * @return {this}
    */
-  public resize = async (): Promise<void> => {
+  public async resize(): Promise<void> {
     const viewport = this._viewport;
     const renderer = this._renderer;
     const camera = this._camera;
@@ -1060,7 +1062,7 @@ class Flicking extends Component<FlickingEvents> {
       sizeChanged,
       element: viewport.element
     }));
-  };
+  }
 
   /**
    * Add new panels after the last panel

--- a/src/cfc/withFlickingMethods.ts
+++ b/src/cfc/withFlickingMethods.ts
@@ -1,3 +1,5 @@
+import Component from "@egjs/component";
+
 import Flicking from "../Flicking";
 
 /**
@@ -16,36 +18,35 @@ import Flicking from "../Flicking";
  * ```
  */
 const withFlickingMethods = (prototype: any, flickingName: string) => {
-  Object.getOwnPropertyNames(Flicking.prototype)
-    .filter(name => !prototype[name] && !name.startsWith("_") && name !== "constructor")
-    .forEach((name: keyof Flicking) => {
-      const descriptor = Object.getOwnPropertyDescriptor(Flicking.prototype, name)!;
+  [Component.prototype, Flicking.prototype].forEach(proto => {
+    Object.getOwnPropertyNames(proto).filter(name => !prototype[name] && !name.startsWith("_") && name !== "constructor")
+      .forEach((name: string) => {
+        const descriptor = Object.getOwnPropertyDescriptor(proto, name)!;
 
-      if (descriptor.value) {
-        // Public Function
-        Object.defineProperty(prototype, name, {
-          value: function(...args) {
-            return descriptor.value.call(this[flickingName], ...args);
+        if (descriptor.value) {
+          // Public Function
+          Object.defineProperty(prototype, name, {
+            value: function(...args) {
+              return descriptor.value.call(this[flickingName], ...args);
+            }
+          });
+        } else {
+          const getterDescriptor: { get?: () => any; set?: (val: any) => void } = {};
+          if (descriptor.get) {
+            getterDescriptor.get = function() {
+              return descriptor.get?.call(this[flickingName]);
+            };
           }
-        });
-      } else {
-        const getterDescriptor: { get?: () => any; set?: (val: any) => void } = {};
-        if (descriptor.get) {
-          getterDescriptor.get = function() {
-            return descriptor.get?.call(this[flickingName]);
-          };
-        }
-        if (descriptor.set) {
-          getterDescriptor.set = function(...args) {
-            return descriptor.set?.call(this[flickingName], ...args);
-          };
-        }
+          if (descriptor.set) {
+            getterDescriptor.set = function(...args) {
+              return descriptor.set?.call(this[flickingName], ...args);
+            };
+          }
 
-        Object.defineProperty(prototype, name, getterDescriptor);
-      }
-    });
+          Object.defineProperty(prototype, name, getterDescriptor);
+        }
+      });
+  });
 };
 
 export default withFlickingMethods;
-/* eslint-enable @typescript-eslint/no-unsafe-member-access */
-/* eslint-enable @typescript-eslint/no-unsafe-assignment */


### PR DESCRIPTION
## Issue
#458 

## Details
This adds the following missing methods to framework Flickings
- resize
- on, once, trigger, off