### PR TITLE
fix: select event can throw error when there's no element on panel in frameworks

### DIFF
--- a/src/core/panel/Panel.ts
+++ b/src/core/panel/Panel.ts
@@ -306,7 +306,7 @@ abstract class Panel {
    * @return {boolean} A Boolean value indicating the element is inside of this panel {@link Panel#element element}<ko>패널의 {@link Panel#element element}내에 해당 엘리먼트 포함 여부</ko>
    */
   public contains(element: HTMLElement): boolean {
-    return this.element.contains(element);
+    return !!this.element?.contains(element);
   }
 
   /**

--- a/test/unit/core/Panel.spec.ts
+++ b/test/unit/core/Panel.spec.ts
@@ -427,5 +427,36 @@ describe("Panel", () => {
         expect((await createPanel(El.panel(), { index: 10 })).decreaseIndex(-99).index).to.equal(10);
       });
     });
+
+    describe("contains", () => {
+      it("should return true if element is a child of given panel's element", async () => {
+        const panel = await createPanel(El.panel(), { index: 0 });
+        const childEl = new El("test");
+
+        panel.element.appendChild(childEl.el);
+
+        expect(panel.contains(childEl.el)).to.be.true;
+      });
+
+      it("should return false if element is not a child of given panel's element", async () => {
+        const panel = await createPanel(El.panel(), { index: 0 });
+        const childEl = new El("test");
+
+        panel.element.parentElement.appendChild(childEl.el);
+
+        expect(panel.contains(childEl.el)).to.be.false;
+      });
+
+      it("should return false if element is null", async () => {
+        const panel = await createPanel(El.panel(), { index: 0 });
+        const childEl = new El("test");
+
+        panel.element.appendChild(childEl.el);
+        (panel as any)._el = null;
+
+        expect(panel.element).equals(null);
+        expect(panel.contains(childEl.el)).to.be.false;
+      });
+    });
   });
 });


### PR DESCRIPTION
## Issue
#468 

## Details
This fixes #468 
