### PR TITLE
fix: set axes releaseOnScroll to true

### DIFF
--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -102,7 +102,8 @@ class AxesController {
     this._panInput = new PanInput(flicking.viewport.element, {
       inputType: flicking.inputType,
       iOSEdgeSwipeThreshold: flicking.iOSEdgeSwipeThreshold,
-      scale: flicking.horizontal ? [-1, 0] : [0, -1]
+      scale: flicking.horizontal ? [-1, 0] : [0, -1],
+      releaseOnScroll: true
     });
 
     const axes = this._axes;


### PR DESCRIPTION
## Details
This restores missing `releaseOnScroll` option for Axes that was previously used in Flicking v3
