### PR TITLE
fix: set new currentPanel when current is removed

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -769,7 +769,10 @@ class Flicking extends Component<{
     }
     panelManager.replacePanels(newPanels, newClones);
 
-    if (!currentPanel && newPanels.length > 0) {
+    const currentPanelIndex = currentPanel?.getIndex() ?? -1;
+    const currentPanelIsRemoved = findIndex(removed, index => index === currentPanelIndex) >= 0;
+
+    if ((!currentPanel || currentPanelIsRemoved) && newPanels.length > 0) {
       viewport.setCurrentPanel(newPanels[0]);
     } else if (newPanels.length <= 0) {
       viewport.setCurrentPanel(undefined);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -169,7 +169,7 @@ export function getProgress(pos: number, range: number[]) {
 export function findIndex<T>(iterable: T[], callback: (el: T) => boolean): number {
   for (let i = 0; i < iterable.length; i += 1) {
     const element = iterable[i];
-    if (element && callback(element)) {
+    if (element != null && callback(element)) {
       return i;
     }
   }

--- a/test/unit/methods.spec.ts
+++ b/test/unit/methods.spec.ts
@@ -1838,6 +1838,30 @@ describe("Methods call", () => {
           expect(panel.getPosition()).is.greaterThan(prevPanel.getPosition());
         });
       });
+
+      it("should replace current panel when it's removed", () => {
+        // Given
+        flickingInfo = createFlicking(horizontal.full, {
+          renderExternal: true,
+        });
+        const flicking = flickingInfo.instance;
+
+        // When
+        const prevCurrentPanel = flicking.getCurrentPanel();
+        const newElements = renderOriginalElement(1, "panel-horizontal-100px");
+        flicking.sync({
+          list: [...newElements],
+          maintained: [],
+          added: [0],
+          changed: [],
+          removed: [0, 1, 2]
+        });
+
+        // Then
+        expect(prevCurrentPanel).not.to.be.null;
+        expect(prevCurrentPanel.getElement()).not.to.equal(flicking.getCurrentPanel().getElement());
+        expect(flicking.getCurrentPanel().getElement()).to.equal(newElements[0]);
+      });
     });
 
     describe("sync() in circular mode", () => {


### PR DESCRIPTION
## Details
This fixes case that flicking doesn't update `currentPanel` after calling `sync`
