### PR TITLE
fix: plugins are not updated on Svelte

### DIFF
--- a/packages/svelte-flicking/src/flicking.svelte
+++ b/packages/svelte-flicking/src/flicking.svelte
@@ -131,6 +131,8 @@
 
     // Flush pending panels
     pendingPanels.splice(0, pendingPanels.length);
+
+    checkPlugins();
   });
 
   function getChildren() {


### PR DESCRIPTION
## Details
This fixes issue that plugins are not updated on svelte after initialization
