### PR TITLE
fix: bound not working when there're not enough panels to fill the viewport

### DIFF
--- a/src/camera/BoundCamera.ts
+++ b/src/camera/BoundCamera.ts
@@ -4,7 +4,7 @@
  */
 import Panel from "../core/panel/Panel";
 import AnchorPoint from "../core/AnchorPoint";
-import { getFlickingAttached } from "../utils";
+import { getFlickingAttached, parseAlign } from "../utils";
 
 import Camera from "./Camera";
 
@@ -39,12 +39,22 @@ class BoundCamera extends Camera {
     const firstPanelPrev = firstPanel.range.min;
     const lastPanelNext = lastPanel.range.max;
     const panelAreaSize = lastPanelNext - firstPanelPrev;
-    const canSetBoundMode = viewportSize < panelAreaSize;
+    const isBiggerThanViewport = viewportSize < panelAreaSize;
 
-    if (canSetBoundMode) {
-      this._range = { min: firstPanelPrev + alignPos, max: lastPanelNext - viewportSize + alignPos };
+    const firstPos = firstPanelPrev + alignPos;
+    const lastPos = lastPanelNext - viewportSize + alignPos;
+
+    if (isBiggerThanViewport) {
+      this._range = { min: firstPos, max: lastPos };
     } else {
-      this._range = { min: firstPanel.position, max: lastPanel.position };
+      const align = this._align;
+      const alignVal = typeof align === "object"
+        ? (align as { camera: string | number }).camera
+        : align;
+
+      const pos = firstPos + parseAlign(alignVal, lastPos - firstPos);
+
+      this._range = { min: pos, max: pos };
     }
 
     return this;

--- a/test/manual/js/index.js
+++ b/test/manual/js/index.js
@@ -1,6 +1,5 @@
 const flicking = new Flicking("#flicking", {
-  align: "center",
-  panelsPerView: 2,
+  align: "10%",
   bound: true
 });
 

--- a/test/unit/camera/BoundCamera.spec.ts
+++ b/test/unit/camera/BoundCamera.spec.ts
@@ -40,7 +40,7 @@ describe("BoundCamera", () => {
         });
       });
 
-      it("should set range from first panel's position to last panel's position when sum of panel size is smaller than viewport size", async () => {
+      it("should set range by align value when sum of panel size is same or smaller than viewport size", async () => {
         const camera = new BoundCamera();
         const flicking = await createFlicking(
           El.viewport().setWidth(900).add(
@@ -48,7 +48,8 @@ describe("BoundCamera", () => {
               .add(El.panel("300px"))
               .add(El.panel("300px"))
               .add(El.panel("300px"))
-          )
+          ),
+          { align: "center" }
         );
 
         camera.init(flicking);
@@ -56,12 +57,26 @@ describe("BoundCamera", () => {
         camera.updateRange();
 
         expect(camera.range).to.deep.equal({
-          min: flicking.getPanel(0).position,
-          max: flicking.getPanel(2).position
+          min: 450,
+          max: 450
         });
-        expect(camera.range).not.to.deep.equal({
-          min: flicking.getPanel(0).range.min + camera.alignPosition,
-          max: flicking.getPanel(2).range.max - camera.alignPosition
+
+        camera.align = "prev";
+
+        camera.updateAlignPos();
+        camera.updateRange();
+        expect(camera.range).to.deep.equal({
+          min: 0,
+          max: 0
+        });
+
+        camera.align = "next";
+
+        camera.updateAlignPos();
+        camera.updateRange();
+        expect(camera.range).to.deep.equal({
+          min: 900,
+          max: 900
         });
       });
     });


### PR DESCRIPTION
## Issue
#505 

## Details
This fixes #505 

"prev"
![image](https://user-images.githubusercontent.com/26213435/129690917-fbc67d0c-5c63-42ae-a4b2-6f7cdcb1dd87.png)

"next"
![image](https://user-images.githubusercontent.com/26213435/129690961-1aefebe2-b2ee-4613-b945-a4b98918276e.png)

"center"
![image](https://user-images.githubusercontent.com/26213435/129690991-bc0025e6-65d2-43ce-b3c2-41f8b991d074.png)

"20%"
![image](https://user-images.githubusercontent.com/26213435/129691035-da0d1f1d-70c0-40f3-8679-5a8669804080.png)

