### PR TITLE
docs: rollback lazyload demo

### DIFF
--- a/docs/src/demo/code/LazyLoad/js.tsx
+++ b/docs/src/demo/code/LazyLoad/js.tsx
@@ -15,7 +15,7 @@ export default <><Columns>
 <Columns>
   <ColumnItem is={12}>
     <CodeBlock className="js" title="js">
-      {`import Flicking, { ALIGN, EVENT } from "@egjs/flicking";
+      {`import Flicking, { ALIGN, EVENTS } from "@egjs/flicking";
 
 // Add panel elements
 const cameraEl = document.querySelector("#flick .flicking-camera");
@@ -25,6 +25,7 @@ for (let i = 0; i <= 500; i++) {
   const panel = document.createElement("div");
   panel.innerHTML = "<span>" + i + "</span>"
   panel.__LOADED__ = false;
+  fragment.appendChild(panel);
 }
 
 cameraEl.appendChild(fragment);
@@ -44,7 +45,7 @@ const updateVisibility(indexes: number[]) {
       const image = document.createElement("img");
       image.src = "https://cataas.com/cat?idx=" + panel.index
       panel.element.appendChild(image);
-      apnel.element.__LOADED__ = true;
+      panel.element.__LOADED__ = true;
     });
 }
 

--- a/docs/src/pages/Demos.mdx
+++ b/docs/src/pages/Demos.mdx
@@ -46,6 +46,3 @@ Made with [@egjs/grid](https://github.com/naver/egjs-grid)
 
 ## Date Selector
 <DateSelector />
-
-## Lazyload Panels
-<LazyLoad />


### PR DESCRIPTION
## Details
This will remove the pre-deployed lazyload demo, as it's not properly prepared yet.
That demo can have memory issues with old devices, so I'll remove that demo for now, and will add it again when it's prepared.
