### PR TITLE
fix: svelte ssr constructor not found

### DIFF
--- a/packages/svelte-flicking/src/Flicking.js
+++ b/packages/svelte-flicking/src/Flicking.js
@@ -6,6 +6,8 @@ import { withFlickingMethods } from "@egjs/flicking";
 
 import SvelteFlicking from "./flicking.svelte";
 
-withFlickingMethods(SvelteFlicking.prototype, "vanillaFlicking");
+if (SvelteFlicking.prototype) {
+  withFlickingMethods(SvelteFlicking.prototype, "vanillaFlicking");
+}
 
 export default SvelteFlicking;


### PR DESCRIPTION
## Issue
#612 

## Details
This fixes #612 
