### PR TITLE
docs: Fix class to className in example

### DIFF
--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -83,9 +83,9 @@ export default () => (
     onMoveEnd={e => {
       console.log(e);
     }}>
-    <div class="panel">1</div>
-    <div class="panel">2</div>
-    <div class="panel">3</div>
+    <div className="panel">1</div>
+    <div className="panel">2</div>
+    <div className="panel">3</div>
   </Flicking>
 )
 ```

--- a/docs/docs/quick-start.mdx
+++ b/docs/docs/quick-start.mdx
@@ -324,9 +324,9 @@ export default () => (
     onMoveEnd={e => {
       console.log(e);
     }}>
-    <div class="panel">1</div>
-    <div class="panel">2</div>
-    <div class="panel">3</div>
+    <div className="panel">1</div>
+    <div className="panel">2</div>
+    <div className="panel">3</div>
   </Flicking>
 )
 ```


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
Closes https://github.com/naver/egjs-flicking/issues/639

## Details
<!-- Detailed description of the change/feature -->
`class` is not used in React(JSX)

This resolves #639 