### PR TITLE
fix: broken rendering on React 18

### DIFF
--- a/docs/src/demo/DateSelector.tsx
+++ b/docs/src/demo/DateSelector.tsx
@@ -5,9 +5,6 @@ import Flicking, { ViewportSlot } from "@egjs/react-flicking";
 import SourceCode from "@site/src/component/SourceCode";
 import "../css/demo/date-selector.css";
 
-const days = [...new Array(31).keys()].map((_, idx) => idx);
-const years = [...new Array(100).keys()].map((_, idx) => 1970 + idx);
-
 const updateTransform = e => {
   e.currentTarget.panels.forEach(panel => {
     const rotateVal = -panel.progress * 20;
@@ -16,6 +13,8 @@ const updateTransform = e => {
     panel.element.style.transform = `translateZ(-${depth}px) rotateX(${rotateVal}deg)`;
   });
 };
+
+export const dates = (start: number, count: number) => (Array.apply(0, Array(count)) as number[]).map((_, idx) => <div key={idx} className="date-panel is-size-4 has-text-weight-bold">{start + idx}</div>);
 
 export default () => <>
   <div className="date-demo-wrapper p-4 has-background-black has-text-white">
@@ -43,7 +42,7 @@ export default () => <>
     <Flicking className="date-flicking" horizontal={false}
       onReady={updateTransform}
       onMove={updateTransform}>
-      { days.map(day => <div key={day} className="date-panel is-size-4 has-text-weight-bold">{day + 1}</div>) }
+      { dates(1, 31) }
       <ViewportSlot>
         <div className="date-panel-border"></div>
         <div className="shadow-top"></div>
@@ -53,7 +52,7 @@ export default () => <>
     <Flicking className="date-flicking" horizontal={false}
       onReady={updateTransform}
       onMove={updateTransform}>
-      { years.map(year => <div key={year} className="date-panel is-size-4 has-text-weight-bold">{year}</div>) }
+      { dates(1970, 100) }
       <ViewportSlot>
         <div className="date-panel-border"></div>
         <div className="shadow-top"></div>

--- a/packages/react-flicking/package.json
+++ b/packages/react-flicking/package.json
@@ -8,7 +8,7 @@
   "es2015": "dist/flicking.esm.js",
   "types": "declaration/index.d.ts",
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "react-scripts start",
     "build": "rollup -c && npm run declaration",
     "postbuild": "cpx 'node_modules/@egjs/flicking/dist/*.{css,css.map}' dist/",
     "declaration": "rm -rf declaration && tsc -p tsconfig.declaration.json",

--- a/packages/react-flicking/src/demo/App.tsx
+++ b/packages/react-flicking/src/demo/App.tsx
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import {
   BrowserRouter as Router,
-  Switch,
+  Routes,
   Route
 } from "react-router-dom";
 import "./css/common.css";
@@ -29,52 +29,24 @@ import Header from "./Header";
 export default class App extends Component<{}> {
   public render() {
     return (
-    <React.StrictMode>
       <Router>
         <Header/>
-        <Switch>
-          <Route path="/infinite">
-            <InfiniteFlicking />
-          </Route>
-          <Route path="/free-scroll">
-            <FreeScroll />
-          </Route>
-          <Route path="/variable-size">
-            <VariableSize />
-          </Route>
-          <Route path="/align">
-            <Align />
-          </Route>
-          <Route path="/snap">
-            <Snap />
-          </Route>
-          <Route path="/gap">
-            <Gap />
-          </Route>
-          <Route path="/progress">
-            <Progress />
-          </Route>
-          <Route path="/bound">
-            <Bound />
-          </Route>
-          <Route path="/virtual">
-            <Virtual />
-          </Route>
-          <Route path="/parallax">
-            <Parallax />
-          </Route>
-          <Route path="/fade">
-            <Fade />
-          </Route>
-          <Route path="/autoplay">
-            <AutoPlay />
-          </Route>
-          <Route path="/arrow">
-            <Arrow />
-          </Route>
-        </Switch>
-      </Router>
-    </React.StrictMode>);
+        <Routes>
+          <Route path="/infinite" element={<InfiniteFlicking />} />
+          <Route path="/free-scroll" element={<FreeScroll />} />
+          <Route path="/variable-size" element={<VariableSize />} />
+          <Route path="/align" element={<Align />} />
+          <Route path="/snap" element={<Snap />} />
+          <Route path="/gap" element={<Gap />} />
+          <Route path="/progress" element={<Progress />} />
+          <Route path="/bound" element={<Bound />} />
+          <Route path="/virtual" element={<Virtual />} />
+          <Route path="/parallax" element={<Parallax />} />
+          <Route path="/fade" element={<Fade />} />
+          <Route path="/autoplay" element={<AutoPlay />} />
+          <Route path="/arrow" element={<Arrow />} />
+        </Routes>
+      </Router>);
   }
   public componentDidMount() {
     hljs.initHighlighting();

--- a/packages/react-flicking/src/demo/features/FreeScroll.tsx
+++ b/packages/react-flicking/src/demo/features/FreeScroll.tsx
@@ -11,7 +11,7 @@ export default class FreeScroll extends React.Component<{}> {
         <li>The panels are freely scrollable.</li>
       </ul>
       <h2>moveType: "freeScroll", deceleration: 0.0075(default)</h2>
-      <Flicking className="flicking flicking0" gap={10} circular={true} moveType="freeScroll">
+      <Flicking className="flicking flicking0" gap={10} circular={true} moveType="freeScroll" renderOnlyVisible>
         <div className="panel panel0"></div>
         <div className="panel panel1"></div>
         <div className="panel panel2"></div>

--- a/packages/react-flicking/src/index.tsx
+++ b/packages/react-flicking/src/index.tsx
@@ -1,9 +1,12 @@
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import App from "./demo/App";
 import * as serviceWorker from "./demo/serviceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(<App />);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -124,6 +124,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
 
     this._checkPlugins();
     renderEmitter.trigger("render");
+    flicking.camera.updateOffset();
 
     this._currentState = LifeCycleState.UPDATED;
 

--- a/packages/react-flicking/src/react-flicking/ReactRenderer.ts
+++ b/packages/react-flicking/src/react-flicking/ReactRenderer.ts
@@ -28,11 +28,16 @@ class ReactRenderer extends ExternalRenderer {
     const reactFlicking = this._reactFlicking;
     const strategy = this._strategy;
 
+    this._rendering = true;
+
     strategy.updateRenderingPanels(flicking);
     strategy.renderPanels(flicking);
 
     return new Promise<void>(resolve => {
-      reactFlicking.renderEmitter.once("render", resolve);
+      reactFlicking.renderEmitter.once("render", () => {
+        this._rendering = false;
+        resolve()
+      });
       reactFlicking.forceUpdate();
     });
   }
@@ -40,10 +45,14 @@ class ReactRenderer extends ExternalRenderer {
   public async forceRenderAllPanels() {
     const reactFlicking = this._reactFlicking;
 
+    this._rendering = true;
     await super.forceRenderAllPanels();
 
     return new Promise<void>(resolve => {
-      reactFlicking.renderEmitter.once("render", resolve);
+      reactFlicking.renderEmitter.once("render", () => {
+        this._rendering = false;
+        resolve();
+      });
       reactFlicking.forceUpdate();
     });
   }

--- a/packages/react-flicking/tsconfig.json
+++ b/packages/react-flicking/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
     "lib": [

--- a/packages/react-flicking/tsconfig.paths.json
+++ b/packages/react-flicking/tsconfig.paths.json
@@ -1,8 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "~/*": ["../../src/*"]
-    }
-  }
-}

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -853,10 +853,9 @@ class Flicking extends Component<FlickingEvents> {
     }
     renderer.checkPanelContentsReady(renderer.panels);
 
-    this._plugins.forEach(plugin => plugin.init(this));
-
     return renderer.render().then(() => {
       // Done initializing & emit ready event
+      this._plugins.forEach(plugin => plugin.init(this));
       this._initialized = true;
       if (preventEventsBeforeInit) {
         this.trigger = originalTrigger;

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -816,10 +816,10 @@ class Flicking extends Component<FlickingEvents> {
    * @ko Flicking을 초기화하고, 디폴트 인덱스로 이동합니다
    * 이 메소드는 `autoInit` 옵션이 true(default)일 경우 Flicking이 생성될 때 자동으로 호출됩니다
    * @fires Flicking#ready
-   * @return {this}
+   * @return {Promise<void>}
    */
-  public async init(): Promise<void> {
-    if (this._initialized) return;
+  public init(): Promise<void> {
+    if (this._initialized) return Promise.resolve();
 
     const camera = this._camera;
     const renderer = this._renderer;
@@ -828,7 +828,7 @@ class Flicking extends Component<FlickingEvents> {
     const originalTrigger = this.trigger;
     const preventEventsBeforeInit = this._preventEventsBeforeInit;
 
-    camera.init(this);
+    camera.init();
     virtualManager.init();
     renderer.init(this);
     control.init(this);
@@ -837,10 +837,10 @@ class Flicking extends Component<FlickingEvents> {
       this.trigger = () => this;
     }
 
-    await this.resize();
+    this._initialResize();
 
     // Look at initial panel
-    await this._moveToInitialPanel();
+    this._moveToInitialPanel();
 
     if (this._autoResize) {
       this._autoResizer.enable();
@@ -855,14 +855,14 @@ class Flicking extends Component<FlickingEvents> {
 
     this._plugins.forEach(plugin => plugin.init(this));
 
-    // Done initializing & emit ready event
-    this._initialized = true;
-    if (preventEventsBeforeInit) {
-      this.trigger = originalTrigger;
-    }
-    this.trigger(new ComponentEvent(EVENTS.READY));
-
-    return;
+    return renderer.render().then(() => {
+      // Done initializing & emit ready event
+      this._initialized = true;
+      if (preventEventsBeforeInit) {
+        this.trigger = originalTrigger;
+      }
+      this.trigger(new ComponentEvent(EVENTS.READY));
+    });
   }
 
   /**
@@ -1379,7 +1379,7 @@ class Flicking extends Component<FlickingEvents> {
       console.warn("\"circular\" and \"bound\" option cannot be used together, ignoring bound.");
     }
 
-    return new Camera({
+    return new Camera(this, {
       align: this._align
     });
   }
@@ -1420,18 +1420,66 @@ class Flicking extends Component<FlickingEvents> {
     });
   }
 
-  private async _moveToInitialPanel(): Promise<void> {
+  private _moveToInitialPanel(): void {
     const renderer = this._renderer;
     const control = this._control;
+    const camera = this._camera;
     const initialPanel = renderer.getPanel(this._defaultIndex) || renderer.getPanel(0);
 
     if (!initialPanel) return;
 
+    const nearestAnchor = camera.findNearestAnchor(initialPanel.position);
     control.setActive(initialPanel, null, false);
 
-    return control.moveToPanel(initialPanel, {
-      duration: 0
-    });
+    if (!nearestAnchor) {
+      throw new FlickingError(ERROR.MESSAGE.POSITION_NOT_REACHABLE(initialPanel.position), ERROR.CODE.POSITION_NOT_REACHABLE);
+    }
+
+    let position = initialPanel.position;
+
+    if (!camera.canReach(initialPanel)) {
+      position = nearestAnchor.position;
+    }
+
+    camera.lookAt(position);
+    control.updateInput();
+    camera.updateOffset();
+  }
+
+  private _initialResize() {
+    const viewport = this._viewport;
+    const renderer = this._renderer;
+    const camera = this._camera;
+    const control = this._control;
+
+    this.trigger(new ComponentEvent(EVENTS.BEFORE_RESIZE, {
+      width: 0,
+      height: 0,
+      element: viewport.element
+    }));
+
+    viewport.resize();
+    renderer.updatePanelSize();
+    camera.updateAlignPos();
+    camera.updateRange();
+    camera.updateAnchors();
+    camera.updateOffset();
+    control.updateInput();
+
+    const newWidth = viewport.width;
+    const newHeight = viewport.height;
+    const sizeChanged = newWidth !== 0 || newHeight !== 0;
+
+    this.trigger(new ComponentEvent(EVENTS.AFTER_RESIZE, {
+      width: viewport.width,
+      height: viewport.height,
+      prev: {
+        width: 0,
+        height: 0
+      },
+      sizeChanged,
+      element: viewport.element
+    }));
   }
 }
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -27,6 +27,7 @@ abstract class Renderer {
   // Internal States
   protected _flicking: Flicking | null;
   protected _panels: Panel[];
+  protected _rendering: boolean;
 
   // Options
   protected _align: NonNullable<RendererOptions["align"]>;
@@ -41,6 +42,14 @@ abstract class Renderer {
    * @see Panel
    */
   public get panels() { return this._panels; }
+  /**
+   * A boolean value indicating whether rendering is in progress
+   * @ko 현재 렌더링이 시작되어 끝나기 전까지의 상태인지의 여부
+   * @type {boolean}
+   * @readonly
+   * @internal
+   */
+  public get rendering() { return this._rendering; }
   /**
    * Count of panels
    * @ko 전체 패널의 개수
@@ -80,6 +89,7 @@ abstract class Renderer {
   }: RendererOptions) {
     this._flicking = null;
     this._panels = [];
+    this._rendering = false;
 
     // Bind options
     this._align = align;
@@ -367,6 +377,7 @@ abstract class Renderer {
       if (!flicking.initialized) return;
 
       camera.updateRange();
+      camera.updateOffset();
       camera.updateAnchors();
 
       if (control.animating) {
@@ -402,6 +413,7 @@ abstract class Renderer {
     const { camera, control } = flicking;
 
     camera.updateRange();
+    camera.updateOffset();
     camera.updateAnchors();
     camera.resetNeedPanelHistory();
     control.updateInput();

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -7,7 +7,7 @@
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/es6-promise/dist/es6-promise.auto.js"></script>
   <script type="text/javascript" src="../../dist/flicking.pkgd.js"></script>
   <link rel="stylesheet" href="./css/index.css">
-  <link rel="stylesheet" href="../../css/flicking.css">
+  <link rel="stylesheet" href="../../dist/css/flicking.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css">
   <title>Flicking Manual Test</title>
 </head>

--- a/test/manual/index.html
+++ b/test/manual/index.html
@@ -6,6 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/es6-promise/dist/es6-promise.auto.js"></script>
   <script type="text/javascript" src="../../dist/flicking.pkgd.js"></script>
+  <script type="text/javascript" src="../../node_modules/@egjs/flicking-plugins/dist/plugins.js"></script>
   <link rel="stylesheet" href="./css/index.css">
   <link rel="stylesheet" href="../../dist/css/flicking.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css">

--- a/test/manual/js/index.js
+++ b/test/manual/js/index.js
@@ -1,7 +1,12 @@
 const flicking = new Flicking("#flicking", {
   moveType: "strict",
   renderOnlyVisible: true
+}).on("ready", () => {
+  console.log("ready");
 });
+
+const plugin = new Flicking.Plugins.AutoPlay({ duration: 2000 });
+flicking.addPlugins(plugin);
 
 new Array(6).fill(0).map((_, idx) => {
   document.querySelector(`#btn-${idx}`).addEventListener("click", () => {

--- a/test/manual/js/index.js
+++ b/test/manual/js/index.js
@@ -1,6 +1,6 @@
 const flicking = new Flicking("#flicking", {
-  circular: true,
-  moveType: "strict"
+  moveType: "strict",
+  renderOnlyVisible: true
 });
 
 new Array(6).fill(0).map((_, idx) => {

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -1172,15 +1172,6 @@ describe("Flicking", () => {
         expect(rendererSpy.calledOnce).to.be.true;
       });
 
-      it("should call resize of it", async () => {
-        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
-        const resizeSpy = sinon.spy(flicking, "resize");
-
-        await flicking.init();
-
-        expect(resizeSpy.calledOnce).to.be.true;
-      });
-
       it("should move to default index", async () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false, defaultIndex: 1 });
 

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -613,6 +613,98 @@ describe("Flicking", () => {
     });
   });
 
+  describe("Initial rendering", () => {
+    it("should place camera at correct position with default options", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+
+      flicking.init(); // Not awaiting on purpose
+
+      expect(flicking.panels[0].position).not.to.equal(0);
+      expect(flicking.camera.position).to.equal(flicking.panels[0].position);
+      expect(flicking.camera.element.style.transform).to.equal("translate(0px)");
+    });
+
+    it("should place camera & panels at correct position on circular rendering", async () => {
+      const flicking = await createFlicking(
+        El.viewport("1000px", "100%").add(
+          El.camera().add(
+            El.panel().setWidth("300px").setHeight(300),
+            El.panel().setWidth("300px").setHeight(300),
+            El.panel().setWidth("300px").setHeight(300),
+            El.panel().setWidth("300px").setHeight(300),
+            El.panel().setWidth("300px").setHeight(300)
+          )
+        ),
+        { autoInit: false, circular: true }
+      );
+
+      flicking.init(); // Not awaiting on purpose
+
+      const camera = flicking.camera;
+      const firstPanel = flicking.panels[0];
+      const lastPanel = flicking.panels[flicking.panels.length - 1];
+      const translatePos = camera.position - camera.alignPosition - camera.offset;
+
+      expect(firstPanel.position).not.to.equal(0);
+      expect(flicking.camera.position).to.equal(firstPanel.position);
+      expect(lastPanel.toggled).to.be.true;
+      expect(lastPanel.toggleDirection).to.equal(DIRECTION.PREV);
+      expect(lastPanel.position + lastPanel.offset).to.equal(firstPanel.position - lastPanel.sizeIncludingMargin);
+      expect(flicking.camera.element.style.transform).to.equal(`translate(${-(translatePos)}px)`);
+    });
+
+    it("should place camera & panels at correct position on renderOnlyVisible rendering", async () => {
+      const flicking = await createFlicking(
+        El.viewport("1000px", "100%").add(
+          El.camera().add(
+            El.panel().setWidth("30%").setHeight(300),
+            El.panel().setWidth("30%").setHeight(300),
+            El.panel().setWidth("30%").setHeight(300),
+            El.panel().setWidth("30%").setHeight(300),
+            El.panel().setWidth("30%").setHeight(300)
+          )
+        ),
+        { autoInit: false, renderOnlyVisible: true }
+      );
+
+      flicking.init(); // Not awaiting on purpose
+
+      const camera = flicking.camera;
+      const translatePos = camera.position - camera.alignPosition - camera.offset;
+
+      expect(flicking.panels[0].position).not.to.equal(0);
+      expect(flicking.camera.position).to.equal(flicking.panels[0].position);
+      expect(flicking.panels.map(panel => panel.rendered)).to.deep.equal([true, true, true, false, false]);
+      expect(flicking.camera.element.style.transform).to.equal(`translate(${-(translatePos)}px)`);
+    });
+
+    it("should place camera & panels at correct position on circular & renderOnlyVisible rendering", async () => {
+      const flicking = await createFlicking(
+        El.viewport("1000px", "100%").add(
+          El.camera().add(
+            El.panel().setWidth("50%").setHeight(300),
+            El.panel().setWidth("50%").setHeight(300),
+            El.panel().setWidth("50%").setHeight(300),
+            El.panel().setWidth("50%").setHeight(300),
+            El.panel().setWidth("50%").setHeight(300)
+          )
+        ),
+        { autoInit: false, circular: true, renderOnlyVisible: true }
+      );
+
+      flicking.init(); // Not awaiting on purpose
+
+      const camera = flicking.camera;
+      const translatePos = camera.position - camera.alignPosition - camera.offset;
+
+      expect(flicking.panels[0].position).not.to.equal(0);
+      expect(flicking.camera.position).to.equal(flicking.panels[0].position);
+      expect(flicking.camera.element.style.transform).to.equal(`translate(${-(translatePos)}px)`);
+      expect(flicking.panels.map(panel => panel.rendered))
+        .to.deep.equal([true, true, false, false, true]);
+    });
+  });
+
   describe("Events", () => {
     describe(EVENTS.READY, () => {
       it("should be emitted when Flicking is initialized", async () => {

--- a/test/unit/camera/Camera.spec.ts
+++ b/test/unit/camera/Camera.spec.ts
@@ -9,40 +9,47 @@ import El from "../helper/El";
 
 describe("Camera", () => {
   describe("Properties", () => {
-    it("should have element undefined as default", () => {
-      expect(new Camera().element).to.be.undefined;
+    it("should have element undefined as default", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).element).to.be.undefined;
     });
 
-    it("should have position 0 as default", () => {
-      expect(new Camera().position).to.equal(0);
+    it("should have position 0 as default", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).position).to.equal(0);
     });
 
-    it("should have 0 as a default size", () => {
-      expect(new Camera().size).to.equal(0);
+    it("should have 0 as a default size", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).size).to.equal(0);
     });
 
-    it("should have alignPosition 0 as default", () => {
-      expect(new Camera().alignPosition).to.equal(0);
+    it("should have alignPosition 0 as default", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).alignPosition).to.equal(0);
     });
 
-    it("should have range from 0 to 0 as default", () => {
-      expect(new Camera().range.min).to.equal(0);
-      expect(new Camera().range.max).to.equal(0);
+    it("should have range from 0 to 0 as default", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).range.min).to.equal(0);
+      expect(new Camera(flicking).range.max).to.equal(0);
     });
 
-    it("should have visiblePanels as an empty array as default", () => {
-      expect(new Camera().visiblePanels).to.be.empty;
+    it("should have visiblePanels as an empty array as default", async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).visiblePanels).to.be.empty;
     });
 
-    it(`should have align ${ALIGN.CENTER} as default`, () => {
-      expect(new Camera().align).to.equal(ALIGN.CENTER);
+    it(`should have align ${ALIGN.CENTER} as default`, async () => {
+      const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { autoInit: false });
+      expect(new Camera(flicking).align).to.equal(ALIGN.CENTER);
     });
 
     it("should return size same to viewport width when horizontal: true", async () => {
       const flicking = await await createFlicking(El.DEFAULT_HORIZONTAL, { horizontal: true });
-      const camera = new Camera();
+      const camera = new Camera(flicking);
 
-      camera.init(flicking);
+      camera.init();
 
       expect(camera.size).not.to.equal(0);
       expect(camera.size).to.equal(flicking.viewport.width);
@@ -51,9 +58,9 @@ describe("Camera", () => {
 
     it("should return size same to viewport height when horizontal: false", async () => {
       const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { horizontal: false });
-      const camera = new Camera();
+      const camera = new Camera(flicking);
 
-      camera.init(flicking);
+      camera.init();
 
       expect(camera.size).not.to.equal(0);
       expect(camera.size).not.to.equal(flicking.viewport.width);
@@ -61,31 +68,34 @@ describe("Camera", () => {
     });
 
     describe("controlParams", () => {
-      it("should return current range", () => {
-        expect(new Camera().controlParams.range).to.deep.equal(new Camera().range);
+      it("should return current range", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
+        expect(camera.controlParams.range).to.deep.equal(camera.range);
       });
 
       it("should return current position", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(800);
 
         expect(camera.controlParams.position).to.equal(800);
       });
 
-      it("should always return circular as false", () => {
-        expect(new Camera().controlParams.circular).to.be.false;
+      it("should always return circular as false", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        expect(new Camera(flicking).controlParams.circular).to.be.false;
       });
     });
 
     describe("visibleRange", () => {
       it("should return visible range from current position", async () => {
-        const camera = new Camera({ align: ALIGN.CENTER });
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking, { align: ALIGN.CENTER });
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAlignPos();
         camera.lookAt(500);
 
@@ -98,91 +108,83 @@ describe("Camera", () => {
   describe("Methods", () => {
     describe("init", () => {
       it("should throw a FlickingError with code VAL_MUST_NOT_NULL when there's no camera element inside it", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
         // Remove viewport's children
         while (flicking.element.firstChild) {
           flicking.element.firstChild.remove();
         }
 
-        expect(() => camera.init(flicking))
+        expect(() => camera.init())
           .to.throw(FlickingError)
           .with.property("code", ERROR.CODE.VAL_MUST_NOT_NULL);
       });
 
       it("should set first child of the viewport element as its element", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.element).to.equal(flicking.element.firstChild);
       });
 
       it("should use LinearCameraMode by default", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.mode).to.be.an.instanceOf(LinearCameraMode);
       });
 
       it("should use BoundCameraMode when bound is true and the mode is available", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { bound: true });
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.mode).to.be.an.instanceOf(BoundCameraMode);
         expect(camera.mode.checkAvailability()).to.be.true;
       });
 
       it("should use CircularCameraMode when circular is true and the mode is available", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { circular: true });
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.mode).to.be.an.instanceOf(CircularCameraMode);
         expect(camera.mode.checkAvailability()).to.be.true;
       });
 
       it("should use LinearCameraMode when circular is true but it's not available & circularFallback is 'default'", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()), { circular: true, circularFallback: "default" });
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.mode).to.be.an.instanceOf(LinearCameraMode);
       });
 
       it("should use BoundCameraMode when circular is true but it's not available & circularFallback is 'default'", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()), { circular: true, circularFallback: "bound" });
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
 
         expect(camera.mode).to.be.an.instanceOf(BoundCameraMode);
       });
     });
 
     describe("lookAt", () => {
-      it("should throw a FlickingError with code NOT_ATTACHED_TO_FLICKING when it's not initialized yet", async () => {
-        const camera = new Camera();
-
-        expect(() => camera.lookAt(500))
-          .to.throw(FlickingError)
-          .with.property("code", ERROR.CODE.NOT_ATTACHED_TO_FLICKING);
-      });
-
       it("should set position to given value", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
         const prevPosition = camera.position;
 
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(500);
 
         expect(camera.position).not.to.equal(prevPosition);
@@ -190,32 +192,32 @@ describe("Camera", () => {
       });
 
       it("should apply transform to camera element", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(500);
 
         expect(camera.element.style.transform).to.equal(`translate(${-(500 - camera.alignPosition)}px)`);
       });
 
       it("should update visible panels", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(500);
 
         expect(camera.visiblePanels).not.to.be.empty;
       });
 
       it(`should trigger flicking's ${EVENTS.VISIBLE_CHANGE} on visible panels update`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
         const visibleChangeSpy = sinon.spy();
 
         flicking.on(EVENTS.VISIBLE_CHANGE, visibleChangeSpy);
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(500);
 
         await (async () => void 0)();
@@ -224,12 +226,12 @@ describe("Camera", () => {
       });
 
       it(`should trigger flicking's ${EVENTS.NEED_PANEL} for both sides when there're no panels`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
         const needPanelSpy = sinon.spy();
 
         flicking.on(EVENTS.NEED_PANEL, needPanelSpy);
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(500);
 
         expect(needPanelSpy.calledTwice).to.be.true;
@@ -238,12 +240,12 @@ describe("Camera", () => {
       });
 
       it(`should trigger flicking's ${EVENTS.REACH_EDGE} when moving to range.min`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
         const reachEdgeSpy = sinon.spy();
 
         (camera as any)._range = { min: -1000, max: 1000 };
-        camera.init(flicking);
+        camera.init();
         flicking.on(EVENTS.REACH_EDGE, reachEdgeSpy);
         camera.lookAt(-1000);
 
@@ -252,12 +254,12 @@ describe("Camera", () => {
       });
 
       it(`should trigger flicking's ${EVENTS.REACH_EDGE} when moving to range.max`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
         const reachEdgeSpy = sinon.spy();
 
         (camera as any)._range = { min: -1000, max: 1000 };
-        camera.init(flicking);
+        camera.init();
         flicking.on(EVENTS.REACH_EDGE, reachEdgeSpy);
         camera.lookAt(1000);
 
@@ -266,12 +268,12 @@ describe("Camera", () => {
       });
 
       it(`should noot trigger flicking's ${EVENTS.REACH_EDGE} when moving from outside of range to range.min`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
         const reachEdgeSpy = sinon.spy();
 
         (camera as any)._range = { min: -1000, max: 1000 };
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(-1001); // Move to outside
         flicking.on(EVENTS.REACH_EDGE, reachEdgeSpy);
         camera.lookAt(-1000); // Move to outside
@@ -280,12 +282,12 @@ describe("Camera", () => {
       });
 
       it(`should noot trigger flicking's ${EVENTS.REACH_EDGE} when moving from outside of range to range.max`, async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
         const reachEdgeSpy = sinon.spy();
 
         (camera as any)._range = { min: -1000, max: 1000 };
-        camera.init(flicking);
+        camera.init();
         camera.lookAt(1001); // Move to outside
         flicking.on(EVENTS.REACH_EDGE, reachEdgeSpy);
         camera.lookAt(1000); // Move to outside
@@ -296,11 +298,11 @@ describe("Camera", () => {
 
     describe("findAnchorIncludePosition", () => {
       it("should return panel at given position", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
         const panels = flicking.panels;
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAnchors();
 
         expect(camera.findAnchorIncludePosition(panels[0].position).panel).to.equal(panels[0]);
@@ -309,11 +311,11 @@ describe("Camera", () => {
       });
 
       it("should return null when no panel includes given position", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
         const panels = flicking.panels;
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAnchors();
 
         expect(camera.findAnchorIncludePosition(-999999999)).to.be.null;
@@ -325,20 +327,20 @@ describe("Camera", () => {
 
     describe("findNearestAnchor", () => {
       it("should return null when there're no panels", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.viewport().add(El.camera()));
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAnchors();
 
         expect(camera.findNearestAnchor(0)).to.be.null;
       });
 
       it("should return correct panel underneath it", async () => {
-        const camera = new Camera();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking);
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAnchors();
         camera.lookAt(flicking.getPanel(1).position);
 
@@ -365,11 +367,11 @@ describe("Camera", () => {
 
     describe("updateAlignPos", () => {
       it("should update alignPosition using current align value", async () => {
-        const camera = new Camera({ align: "80%" });
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking, { align: "80%" });
         const prevAlignPosition = camera.alignPosition;
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAlignPos();
 
         expect(camera.alignPosition).not.to.equal(prevAlignPosition);
@@ -377,11 +379,11 @@ describe("Camera", () => {
       });
 
       it("should use property 'camera' if align is given as an object", async () => {
-        const camera = new Camera({ align: { panel: "30%", camera: "70%" } });
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const camera = new Camera(flicking, { align: { panel: "30%", camera: "70%" } });
         const prevAlignPosition = camera.alignPosition;
 
-        camera.init(flicking);
+        camera.init();
         camera.updateAlignPos();
 
         expect(camera.alignPosition).not.to.equal(prevAlignPosition);

--- a/test/unit/core/panel/Panel.spec.ts
+++ b/test/unit/core/panel/Panel.spec.ts
@@ -203,17 +203,17 @@ describe("Panel", () => {
         const panel = await createPanel(El.panel().setWidth(1000).setHeight(1000));
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetLeft)).to.be.true;
-        expect(panel.includePosition(panel.element.offsetLeft + 500)).to.be.true;
-        expect(panel.includePosition(panel.element.offsetLeft + 1000)).to.be.true;
+        expect(panel.includePosition(panel.range.min)).to.be.true;
+        expect(panel.includePosition(panel.range.min + 500)).to.be.true;
+        expect(panel.includePosition(panel.range.min + 1000)).to.be.true;
       });
 
       it("should return false when given position is outside of panel", async () => {
         const panel = await createPanel(El.panel().setWidth(1000).setHeight(1000));
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetLeft - 0.1)).to.be.false;
-        expect(panel.includePosition(panel.element.offsetLeft + 1000 + 0.1)).to.be.false;
+        expect(panel.includePosition(panel.range.min - 0.1)).to.be.false;
+        expect(panel.includePosition(panel.range.max + 0.1)).to.be.false;
       });
 
       it("should return false when given position is inside panel margin left/right area when not including margin", async () => {
@@ -222,8 +222,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetLeft - 50, false)).to.be.false;
-        expect(panel.includePosition(panel.element.offsetLeft + 1000 + 50, false)).to.be.false;
+        expect(panel.includePosition(panel.range.min - 50, false)).to.be.false;
+        expect(panel.includePosition(panel.range.max + 50, false)).to.be.false;
       });
 
       it("should return false when given position is inside panel margin top/bottom area when not including margin", async () => {
@@ -232,8 +232,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetTop - 50, false)).to.be.false;
-        expect(panel.includePosition(panel.element.offsetTop + 1000 + 50, false)).to.be.false;
+        expect(panel.includePosition(panel.range.min - 50, false)).to.be.false;
+        expect(panel.includePosition(panel.range.max + 50, false)).to.be.false;
       });
 
       it("should return true when given position is inside panel margin left/right area", async () => {
@@ -242,8 +242,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetLeft - 50, true)).to.be.true;
-        expect(panel.includePosition(panel.element.offsetLeft + 1000 + 50, true)).to.be.true;
+        expect(panel.includePosition(panel.range.min - 50, true)).to.be.true;
+        expect(panel.includePosition(panel.range.max + 50, true)).to.be.true;
       });
 
       it("should return true when given position is inside panel margin top/bottom area", async () => {
@@ -252,8 +252,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetTop - 50, true)).to.be.true;
-        expect(panel.includePosition(panel.element.offsetTop + 1000 + 50, true)).to.be.true;
+        expect(panel.includePosition(panel.range.min - 50, true)).to.be.true;
+        expect(panel.includePosition(panel.range.max + 50, true)).to.be.true;
       });
 
       it("should return false when given position is outside of panel margin left/right area", async () => {
@@ -262,8 +262,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetLeft - 50.1, true)).to.be.false;
-        expect(panel.includePosition(panel.element.offsetLeft + 1000 + 50.1, true)).to.be.false;
+        expect(panel.includePosition(panel.range.min - 50.1, true)).to.be.false;
+        expect(panel.includePosition(panel.range.max + 50.1, true)).to.be.false;
       });
 
       it("should return false when given position is outside of panel margin top/bottom area", async () => {
@@ -272,8 +272,8 @@ describe("Panel", () => {
         );
         panel.resize();
 
-        expect(panel.includePosition(panel.element.offsetTop - 50.1, true)).to.be.false;
-        expect(panel.includePosition(panel.element.offsetTop + 1000 + 50.1, true)).to.be.false;
+        expect(panel.includePosition(panel.range.min - 50.1, true)).to.be.false;
+        expect(panel.includePosition(panel.range.max + 50.1, true)).to.be.false;
       });
     });
 


### PR DESCRIPTION
## Issue
#643 

## Details
This fixes #643 & Flickering behavior in React 18 by changing most of the `init()`'s code to be synchronous.
