### PR TITLE
fix: wrong sync if ordered is included

### DIFF
--- a/src/cfc/sync.ts
+++ b/src/cfc/sync.ts
@@ -2,11 +2,15 @@ import { DiffResult } from "@egjs/list-differ";
 
 import Flicking from "../Flicking";
 import Renderer from "../renderer/Renderer";
+import Panel from "../core/panel/Panel";
 
 export default (flicking: Flicking, diffResult: DiffResult<any>, rendered: any[]) => {
   const renderer = flicking.renderer;
   const panels = renderer.panels;
   const prevList = [...diffResult.prevList];
+
+  const added: Panel[] = [];
+  const removed: Panel[] = [];
 
   if (diffResult.removed.length > 0) {
     let endIdx = -1;
@@ -18,7 +22,7 @@ export default (flicking: Flicking, diffResult: DiffResult<any>, rendered: any[]
       }
 
       if (prevIdx >= 0 && removedIdx !== prevIdx - 1) {
-        batchRemove(renderer, prevIdx, endIdx + 1);
+        removed.push(...batchRemove(renderer, prevIdx, endIdx + 1));
 
         endIdx = removedIdx;
         prevIdx = removedIdx;
@@ -29,30 +33,30 @@ export default (flicking: Flicking, diffResult: DiffResult<any>, rendered: any[]
       prevList.splice(removedIdx, 1);
     });
 
-    batchRemove(renderer, prevIdx, endIdx + 1);
+    removed.push(...batchRemove(renderer, prevIdx, endIdx + 1));
   }
 
-  diffResult.ordered.forEach(([prevIdx, newIdx]) => {
-    const prevPanel = panels[prevIdx];
-    const indexDiff = newIdx - prevIdx;
-
-    if (indexDiff > 0) {
-      const middlePanels = panels.slice(prevIdx + 1, newIdx + 1);
-
-      prevPanel.increaseIndex(indexDiff);
-      middlePanels.forEach(panel => panel.decreaseIndex(1));
-    } else {
-      const middlePanels = panels.slice(newIdx, prevIdx);
-
-      prevPanel.decreaseIndex(-indexDiff);
-      middlePanels.forEach(panel => panel.increaseIndex(1));
-    }
-    // Update position
-    prevPanel.resize();
+  diffResult.ordered.forEach(([from, to]) => {
+    const prevPanel = panels.splice(from, 1)[0];
+    panels.splice(to, 0, prevPanel);
   });
 
   if (diffResult.ordered.length > 0) {
+    panels.forEach((panel, idx) => {
+      const indexDiff = idx - panel.index;
+
+      if (indexDiff > 0) {
+        panel.increaseIndex(indexDiff);
+      } else {
+        panel.decreaseIndex(-indexDiff);
+      }
+    });
+
     panels.sort((panel1, panel2) => panel1.index - panel2.index);
+
+    panels.forEach(panel => {
+      panel.updatePosition();
+    });
   }
 
   if (diffResult.added.length > 0) {
@@ -67,7 +71,7 @@ export default (flicking: Flicking, diffResult: DiffResult<any>, rendered: any[]
       }
 
       if (prevIdx >= 0 && addedIdx !== prevIdx + 1) {
-        batchInsert(renderer, diffResult, addedElements, startIdx, idx + 1);
+        added.push(...batchInsert(renderer, diffResult, addedElements, startIdx, idx + 1));
 
         startIdx = -1;
         prevIdx = -1;
@@ -77,13 +81,15 @@ export default (flicking: Flicking, diffResult: DiffResult<any>, rendered: any[]
     });
 
     if (startIdx >= 0) {
-      batchInsert(renderer, diffResult, addedElements, startIdx);
+      added.push(...batchInsert(renderer, diffResult, addedElements, startIdx));
     }
   }
+
+  renderer.updateAfterPanelChange(added, removed);
 };
 
 const batchInsert = (renderer: Renderer, diffResult: DiffResult<any>, addedElements: any[], startIdx: number, endIdx?: number) => {
-  renderer.batchInsert(
+  return renderer.batchInsertDefer(
     ...diffResult.added.slice(startIdx, endIdx).map((index, elIdx) => ({ index, elements: [addedElements[elIdx]], hasDOMInElements: false }))
   );
 };
@@ -91,6 +97,6 @@ const batchInsert = (renderer: Renderer, diffResult: DiffResult<any>, addedEleme
 const batchRemove = (renderer: Renderer, startIdx: number, endIdx?: number) => {
   const removed = renderer.panels.slice(startIdx, endIdx);
 
-  renderer.batchRemove({ index: startIdx, deleteCount: removed.length, hasDOMInElements: false });
+  return renderer.batchRemoveDefer({ index: startIdx, deleteCount: removed.length, hasDOMInElements: false });
 };
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -182,10 +182,28 @@ abstract class Renderer {
     elements: any[];
     hasDOMInElements: boolean;
   }>): Panel[] {
+    const allPanelsInserted = this.batchInsertDefer(...items);
+
+    if (allPanelsInserted.length <= 0) return [];
+
+    this.updateAfterPanelChange(allPanelsInserted, []);
+
+    return allPanelsInserted;
+  }
+
+  /**
+   * Defers update
+   * camera position & others will be updated after calling updateAfterPanelChange
+   * @internal
+   */
+  public batchInsertDefer(...items: Array<{
+    index: number;
+    elements: any[];
+    hasDOMInElements: boolean;
+  }>) {
     const panels = this._panels;
     const flicking = getFlickingAttached(this._flicking);
 
-    const { control } = flicking;
     const prevFirstPanel = panels[0];
     const align = parsePanelAlign(this._align);
 
@@ -219,30 +237,6 @@ abstract class Renderer {
       return [...addedPanels, ...panelsInserted];
     }, []);
 
-    if (allPanelsInserted.length <= 0) return [];
-
-    // Update camera & control
-    this._updateCameraAndControl();
-
-    void this.render();
-
-    // Move to the first panel added if no panels existed
-    // FIXME: fix for animating case
-    if (allPanelsInserted.length > 0 && !control.animating) {
-      void control.moveToPanel(control.activePanel || allPanelsInserted[0], {
-        duration: 0
-      }).catch(() => void 0);
-    }
-
-    flicking.camera.updateOffset();
-
-    flicking.trigger(new ComponentEvent(EVENTS.PANEL_CHANGE, {
-      added: allPanelsInserted,
-      removed: []
-    }));
-
-    this.checkPanelContentsReady(allPanelsInserted);
-
     return allPanelsInserted;
   }
 
@@ -257,13 +251,35 @@ abstract class Renderer {
    * @param {boolean} [items.hasDOMInElements=1] Whether it contains actual DOM elements. If set to true, renderer will remove them from the camera element<ko>내부에 실제 DOM 엘리먼트들을 포함하고 있는지 여부. true로 설정할 경우, 렌더러는 해당 엘리먼트들을 카메라 엘리먼트 내부에서 제거합니다</ko>
    * @return An array of removed panels<ko>제거된 패널들의 배열</ko>
    */
-  public batchRemove(...items: Array<{ index: number; deleteCount: number; hasDOMInElements: boolean }>): Panel[] {
+  public batchRemove(...items: Array<{
+    index: number;
+    deleteCount: number;
+    hasDOMInElements: boolean;
+  }>): Panel[] {
+    const allPanelsRemoved = this.batchRemoveDefer(...items);
+
+    if (allPanelsRemoved.length <= 0) return [];
+
+    this.updateAfterPanelChange([], allPanelsRemoved);
+
+    return allPanelsRemoved;
+  }
+
+  /**
+   * Defers update
+   * camera position & others will be updated after calling updateAfterPanelChange
+   * @internal
+   */
+  public batchRemoveDefer(...items: Array<{
+    index: number;
+    deleteCount: number;
+    hasDOMInElements: boolean;
+  }>) {
     const panels = this._panels;
     const flicking = getFlickingAttached(this._flicking);
 
-    const { camera, control } = flicking;
+    const { control } = flicking;
     const activePanel = control.activePanel;
-    const activeIndex = control.activeIndex;
 
     const allPanelsRemoved = items.reduce((removed, item) => {
       const { index, deleteCount } = item;
@@ -294,35 +310,56 @@ abstract class Renderer {
       return [...removed, ...panelsRemoved];
     }, []);
 
+    return allPanelsRemoved;
+  }
+
+  /**
+   * @internal
+   */
+  public updateAfterPanelChange(panelsAdded: Panel[], panelsRemoved: Panel[]) {
+    const flicking = getFlickingAttached(this._flicking);
+    const { camera, control } = flicking;
+    const panels = this._panels;
+    const activePanel = control.activePanel;
+
     // Update camera & control
     this._updateCameraAndControl();
 
     void this.render();
 
-    // FIXME: fix for animating case
-    if (allPanelsRemoved.length > 0 && !control.animating) {
-      const targetPanel = includes(allPanelsRemoved, activePanel)
-        ? (panels[activeIndex] || panels[panels.length - 1])
-        : activePanel;
-
-      if (targetPanel) {
-        void control.moveToPanel(targetPanel, {
-          duration: 0
-        }).catch(() => void 0);
-      } else {
+    if (!activePanel || activePanel.removed) {
+      if (panels.length <= 0) {
         // All panels removed
         camera.lookAt(0);
+      } else {
+        let targetIndex = activePanel?.index ?? 0;
+        if (targetIndex > panels.length - 1) {
+          targetIndex = panels.length - 1;
+        }
+
+        void control.moveToPanel(panels[targetIndex], {
+          duration: 0
+        }).catch(() => void 0);
       }
+    } else {
+      void control.moveToPanel(control.activePanel!, {
+        duration: 0
+      }).catch(() => void 0);
     }
 
     flicking.camera.updateOffset();
 
-    flicking.trigger(new ComponentEvent(EVENTS.PANEL_CHANGE, {
-      added: [],
-      removed: allPanelsRemoved
-    }));
+    if (panelsAdded.length > 0 || panelsRemoved.length > 0) {
+      flicking.trigger(new ComponentEvent(EVENTS.PANEL_CHANGE, {
+        added: panelsAdded,
+        removed: panelsRemoved
+      }));
 
-    return allPanelsRemoved;
+      this.checkPanelContentsReady([
+        ...panelsAdded,
+        ...panelsRemoved
+      ]);
+    }
   }
 
   /**


### PR DESCRIPTION
## Details
This fixes the broken `sync` implementation when an entry of `ordered` is included in the diff result.
