### PR TITLE
fix: can't move to adjacent when using strict & circular

### DIFF
--- a/src/camera/Camera.ts
+++ b/src/camera/Camera.ts
@@ -383,25 +383,7 @@ class Camera {
    * @return {AnchorPoint | null} The {@link AnchorPoint} nearest to the given position<ko>해당 좌표에 가장 인접한 {@link AnchorPoint}</ko>
    */
   public findNearestAnchor(position: number): AnchorPoint | null {
-    const anchors = this._anchors;
-
-    if (anchors.length <= 0) return null;
-
-    let prevDist = Infinity;
-    for (let anchorIdx = 0; anchorIdx < anchors.length; anchorIdx++) {
-      const anchor = anchors[anchorIdx];
-      const dist = Math.abs(anchor.position - position);
-
-      if (dist > prevDist) {
-        // Return previous anchor
-        return anchors[anchorIdx - 1];
-      }
-
-      prevDist = dist;
-    }
-
-    // Return last anchor
-    return anchors[anchors.length - 1];
+    return this._mode.findNearestAnchor(position);
   }
 
   /**

--- a/src/camera/mode/CameraMode.ts
+++ b/src/camera/mode/CameraMode.ts
@@ -44,6 +44,28 @@ abstract class CameraMode {
     }, null);
   }
 
+  public findNearestAnchor(position: number): AnchorPoint | null {
+    const anchors = this._flicking.camera.anchorPoints;
+
+    if (anchors.length <= 0) return null;
+
+    let prevDist = Infinity;
+    for (let anchorIdx = 0; anchorIdx < anchors.length; anchorIdx++) {
+      const anchor = anchors[anchorIdx];
+      const dist = Math.abs(anchor.position - position);
+
+      if (dist > prevDist) {
+        // Return previous anchor
+        return anchors[anchorIdx - 1];
+      }
+
+      prevDist = dist;
+    }
+
+    // Return last anchor
+    return anchors[anchors.length - 1];
+  }
+
   public clampToReachablePosition(position: number): number {
     const camera = this._flicking.camera;
     const range = camera.range;

--- a/src/camera/mode/CircularCameraMode.ts
+++ b/src/camera/mode/CircularCameraMode.ts
@@ -64,6 +64,33 @@ class CircularCameraMode extends CameraMode {
     }));
   }
 
+  public findNearestAnchor(position: number): AnchorPoint | null {
+    const camera = this._flicking.camera;
+    const anchors = camera.anchorPoints;
+
+    if (anchors.length <= 0) return null;
+
+    const camRange = camera.range;
+    let minDist = Infinity;
+    let minDistIndex = -1;
+    for (let anchorIdx = 0; anchorIdx < anchors.length; anchorIdx++) {
+      const anchor = anchors[anchorIdx];
+      const dist = Math.min(
+        Math.abs(anchor.position - position),
+        Math.abs(anchor.position - camRange.min + camRange.max - position),
+        Math.abs(position - camRange.min + camRange.max - anchor.position)
+      );
+
+      if (dist < minDist) {
+        minDist = dist;
+        minDistIndex = anchorIdx;
+      }
+    }
+
+    // Return last anchor
+    return anchors[minDistIndex];
+  }
+
   public findAnchorIncludePosition(position: number): AnchorPoint | null {
     const camera = this._flicking.camera;
     const range = camera.range;

--- a/src/control/StrictControl.ts
+++ b/src/control/StrictControl.ts
@@ -219,6 +219,10 @@ class StrictControl extends Control {
     const shouldBounceToFirst = position <= cameraRange.min && isBetween(firstAnchor.panel.index, indexRange.min, indexRange.max);
     const shouldBounceToLast = position >= cameraRange.max && isBetween(lastAnchor.panel.index, indexRange.min, indexRange.max);
 
+    const isAdjacent = adjacentAnchor && (indexRange.min <= indexRange.max
+      ? isBetween(adjacentAnchor.index, indexRange.min, indexRange.max)
+      : adjacentAnchor.index >= indexRange.min || adjacentAnchor.index <= indexRange.max);
+
     if (shouldBounceToFirst || shouldBounceToLast) {
       // In bounce area
       const targetAnchor = position < cameraRange.min ? firstAnchor : lastAnchor;
@@ -229,10 +233,10 @@ class StrictControl extends Control {
       // Move to anchor at position
       targetPanel = anchorAtPosition.panel;
       targetPos = anchorAtPosition.position;
-    } else if (isOverThreshold && adjacentAnchor && isBetween(adjacentAnchor.index, indexRange.min, indexRange.max)) {
+    } else if (isOverThreshold && isAdjacent) {
       // Move to adjacent anchor
-      targetPanel = adjacentAnchor.panel;
-      targetPos = adjacentAnchor.position;
+      targetPanel = adjacentAnchor!.panel;
+      targetPos = adjacentAnchor!.position;
     } else {
       // Restore to active panel
       targetPos = camera.clampToReachablePosition(activePanel.position);

--- a/test/manual/js/index.js
+++ b/test/manual/js/index.js
@@ -1,7 +1,5 @@
 const flicking = new Flicking("#flicking", {
-  moveType: "freeScroll"
-});
-
-flicking.on("willChange", evt => {
-  evt.stop();
+  moveType: "strict",
+  circular: true,
+  align: "prev"
 });

--- a/test/unit/camera/mode/CircularCameraMode.spec.ts
+++ b/test/unit/camera/mode/CircularCameraMode.spec.ts
@@ -1,5 +1,4 @@
 import CircularCameraMode from "~/camera/mode/CircularCameraMode";
-import LinearCameraMode from "~/camera/mode/LinearCameraMode";
 
 import { createFlicking, createPanel } from "../../helper/test-util";
 import El from "../../helper/El";
@@ -132,6 +131,26 @@ describe("CircularCamera", () => {
           min: panels[0].range.min,
           max: panels[2].range.max
         });
+      });
+    });
+
+    describe("findNearestAnchor", () => {
+      it("should return the first anchor when position is 0", async () => {
+        const { camera } = await createFlicking(El.DEFAULT_HORIZONTAL, { circular: true });
+        const anchors = camera.anchorPoints;
+
+        expect(camera.mode).to.be.an.instanceOf(CircularCameraMode);
+        expect(camera.mode.checkAvailability()).to.be.true;
+        expect(camera.mode.findNearestAnchor(0)).to.equal(anchors[0]);
+      });
+
+      it("should return the last anchor when position is below 0", async () => {
+        const { camera } = await createFlicking(El.DEFAULT_HORIZONTAL, { circular: true });
+        const anchors = camera.anchorPoints;
+
+        expect(camera.mode).to.be.an.instanceOf(CircularCameraMode);
+        expect(camera.mode.checkAvailability()).to.be.true;
+        expect(camera.mode.findNearestAnchor(-500)).to.equal(anchors[2]);
       });
     });
   });


### PR DESCRIPTION
## Details
This fixes an issue that Flicking can't move to adjacent panels like 0 -> 1 or last -> 0 when using both strict & circular.