### PR TITLE
feat: add nested option

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -168,3 +168,21 @@ article a {
   width: auto;
   height: 100px;
 }
+
+.nested-wide .flicking-panel {
+  width: 100%;
+  height: 100%;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.nested-wide .nested-wide {
+  padding: 0;
+}
+
+.nested-wide .vertical .flicking-panel {
+  margin-top: 20px;
+  margin-bottom: 20px;
+  margin-right: 0px;
+  margin-left: 0px;
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -163,3 +163,8 @@ article a {
   width: 100%;
   margin: 0;
 }
+
+.nested .flicking-panel {
+  width: auto;
+  height: 100px;
+}

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -170,19 +170,18 @@ article a {
 }
 
 .nested-wide .flicking-panel {
-  width: 100%;
-  height: 100%;
+  width: 75%;
+  height: 140px;
   margin-top: 0;
   margin-bottom: 0;
 }
 
-.nested-wide .nested-wide {
-  padding: 0;
+.nested-wide.vertical {
+  padding-bottom: 10px;
 }
 
-.nested-wide .vertical .flicking-panel {
-  margin-top: 20px;
-  margin-bottom: 20px;
+.nested-wide.vertical .flicking-panel {
+  margin-bottom: 10px;
   margin-right: 0px;
   margin-left: 0px;
 }

--- a/docs/src/demo/Nested.tsx
+++ b/docs/src/demo/Nested.tsx
@@ -1,0 +1,295 @@
+/* eslint-disable @typescript-eslint/indent */
+import React from "react";
+import Flicking from "@egjs/react-flicking";
+import SourceCode from "@site/src/component/SourceCode";
+import CodeBlock from "@theme/CodeBlock";
+import Columns from "@site/src/component/Columns";
+import ColumnItem from "@site/src/component/ColumnItem";
+
+import Panel from "../component/Panel";
+
+export default () => {
+  const vanillaHTML = `<div id="flick1" class="flicking-viewport">
+  <div className="flicking-panel nested-wide">
+    <div id="flick2" class="flicking-viewport">
+      <div className="flicking-panel nested-wide">
+        <div id="flick5" class="flicking-viewport vertical">
+          <div className="flicking-panel">1.09</div>
+          <div className="flicking-panel">1.1</div>
+          <div className="flicking-panel">1.11</div>
+        </div>
+      </div>
+      <div className="flicking-panel">1.2</div>
+      <div className="flicking-panel">1.3</div>
+    </div>
+  </div>
+  <div className="flicking-panel nested-wide">
+    <div id="flick3" class="flicking-viewport">
+      <div className="flicking-panel">2.1</div>
+      <div className="flicking-panel">2.2</div>
+      <div className="flicking-panel">2.3</div>
+    </div>
+  </div>
+  <div className="flicking-panel nested-wide">
+    <div id="flick4" class="flicking-viewport">
+      <div className="flicking-panel">3.1</div>
+      <div className="flicking-panel">3.2</div>
+      <div className="flicking-panel">3.3</div>
+    </div>
+  </div>
+</div>`;
+  const vanillaJS = `const flicking1 = new Flicking("#flick1", {
+  circular: true
+});
+const flicking2 = new Flicking("#flick2", {
+  bounce: 0,
+  bound: true,
+  nested: true
+});
+const flicking3 = new Flicking("#flick3", {
+  bounce: 0,
+  bound: true,
+  nested: true
+});
+const flicking4 = new Flicking("#flick4", {
+  bounce: 0,
+  bound: true,
+  nested: true
+});
+const flicking5 = new Flicking("#flick5", {
+  bounce: 0,
+  bound: true,
+  horizontal: false,
+  defaultIndex: 1,
+  circular: true
+});`;
+  const reactSourceCode = `export default () => {
+    return <>
+      <Flicking circular={true}>
+        <div className="flicking-panel nested-wide">
+          <Flicking bounce="0" bound={true} nested={true}>
+            <div className="flicking-panel nested-wide">
+              <Flicking bounce="0" bound={true} horizontal={false} defaultIndex={1} circular={true}>
+                <div className="flicking-panel">1.09</div>
+                <div className="flicking-panel">1.1</div>
+                <div className="flicking-panel">1.11</div>
+              </Flicking>
+            </div>
+            <div className="flicking-panel">1.2</div>
+            <div className="flicking-panel">1.3</div>
+          </Flicking>
+        </div>
+        <div className="flicking-panel nested-wide">
+          <Flicking bounce="0" bound={true} nested={true}>
+            <div className="flicking-panel">2.1</div>
+            <div className="flicking-panel">2.2</div>
+            <div className="flicking-panel">2.3</div>
+          </Flicking>
+        </div>
+        <div className="flicking-panel nested-wide">
+          <Flicking bounce="0" bound={true} nested={true}>
+            <div className="flicking-panel">3.1</div>
+            <div className="flicking-panel">3.2</div>
+            <div className="flicking-panel">3.3</div>
+          </Flicking>
+        </div>
+      </Flicking>
+    </>
+  };`;
+  const angularSourceCode = `<ngx-flicking [options]="{ circular: true }">
+  <div flicking-panel class="nested-wide">
+    <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
+      <div flicking-panel class="nested-wide">
+        <ngx-flicking [options]="{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }">
+          <div flicking-panel>1.09</div>
+          <div flicking-panel>1.1</div>
+          <div flicking-panel>1.11</div>
+        </div>
+      </div>
+      <div flicking-panel>1.2</div>
+      <div flicking-panel>1.3</div>
+    </div>
+  </div>
+  <div flicking-panel class="nested-wide">
+    <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
+      <div flicking-panel>2.1</div>
+      <div flicking-panel>2.2</div>
+      <div flicking-panel>2.3</div>
+    </div>
+  </div>
+  <div flicking-panel class="nested-wide">
+    <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
+      <div flicking-panel>3.1</div>
+      <div flicking-panel>3.2</div>
+      <div flicking-panel>3.3</div>
+    </div>
+  </div>
+</div>`;
+  const vueSourceCode = `<flicking :options="{ circular: true }">
+  <div class="flicking-panel nested-wide">
+    <flicking :options="{ bounce: 0, bound: true, nested: true }">
+      <div class="flicking-panel nested-wide">
+        <flicking :options="{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }">
+          <div class="flicking-panel">1.09</div>
+          <div class="flicking-panel">1.1</div>
+          <div class="flicking-panel">1.11</div>
+        </flicking>
+      </div>
+      <div class="flicking-panel">1.2</div>
+      <div class="flicking-panel">1.3</div>
+    </flicking>
+  </div>
+  <div class="flicking-panel nested-wide">
+    <flicking :options="{ bounce: 0, bound: true, nested: true }">
+      <div class="flicking-panel">2.1</div>
+      <div class="flicking-panel">2.2</div>
+      <div class="flicking-panel">2.3</div>
+    </flicking>
+  </div>
+  <div class="flicking-panel nested-wide">
+    <flicking :options="{ bounce: 0, bound: true, nested: true }">
+      <div class="flicking-panel">3.1</div>
+      <div class="flicking-panel">3.2</div>
+      <div class="flicking-panel">3.3</div>
+    </flicking>
+  </div>
+</flicking>`;
+  const svelteSourceCode = `<script lang="ts">
+import Flicking, { FlickingPanel } from "@egjs/svelte-flicking";
+</script>
+
+<Flicking options={{ circular: true }}>
+  <FlickingPanel class="nested-wide">
+    <Flicking options={{ bounce: 0, bound: true, nested: true }}>
+      <FlickingPanel class="nested-wide">
+        <Flicking options={{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }}>
+          <FlickingPanel>1.09</FlickingPanel>
+          <FlickingPanel>1.1</FlickingPanel>
+          <FlickingPanel>1.11</FlickingPanel>
+        </Flicking>
+      </FlickingPanel>
+      <FlickingPanel>1.2</FlickingPanel>
+      <FlickingPanel>1.3</FlickingPanel>
+    </Flicking>
+  </FlickingPanel>
+  <FlickingPanel class="nested-wide">
+    <Flicking options={{ bounce: 0, bound: true, nested: true }}>
+      <FlickingPanel>2.1</FlickingPanel>
+      <FlickingPanel>2.2</FlickingPanel>
+      <FlickingPanel>2.3</FlickingPanel>
+    </Flicking>
+  </FlickingPanel>
+  <FlickingPanel class="nested-wide">
+    <Flicking options={{ bounce: 0, bound: true, nested: true }}>
+      <FlickingPanel>3.1</FlickingPanel>
+      <FlickingPanel>3.2</FlickingPanel>
+      <FlickingPanel>3.3</FlickingPanel>
+    </Flicking>
+  </FlickingPanel>
+</Flicking>`;
+
+  return <>
+    <Flicking className="py-4 mb-4" circular={true}>
+      <div className="flicking-panel nested-wide has-background-primary-dark">
+        <Flicking bounce="0" bound={true} nested={true}>
+          <div className="flicking-panel nested-wide">
+            <Flicking bounce="0" bound={true} horizontal={false} style={{ height: "140px" }} defaultIndex={1} circular={true}>
+              <Panel index={0.09} />
+              <Panel index={0.1} />
+              <Panel index={0.11} />
+            </Flicking>
+          </div>
+          <Panel index={0.2} />
+          <Panel index={0.3} />
+        </Flicking>
+      </div>
+      <div className="flicking-panel nested-wide has-background-primary-dark">
+        <Flicking bounce="0" bound={true} nested={true}>
+          <Panel index={1.1} />
+          <Panel index={1.2} />
+          <Panel index={1.3} />
+        </Flicking>
+      </div>
+      <div className="flicking-panel nested-wide has-background-primary-dark">
+        <Flicking bounce="0" bound={true} nested={true}>
+          <Panel index={2.1} />
+          <Panel index={2.2} />
+          <Panel index={2.3} />
+        </Flicking>
+      </div>
+    </Flicking>
+    <SourceCode
+      options={{ circular: true }} panels={[]}
+      js={
+<Columns>
+  <ColumnItem is={6}>
+    <CodeBlock className="language-html" title="html">
+      { vanillaHTML }
+    </CodeBlock>
+  </ColumnItem>
+  <ColumnItem is={6}>
+    <CodeBlock className="language-js" title="js">
+      { vanillaJS }
+    </CodeBlock>
+  </ColumnItem>
+</Columns>}
+  react={
+    <CodeBlock className="language-jsx" title="DemoComponent.jsx">
+{ reactSourceCode }
+    </CodeBlock>
+  }
+  vue={
+    <><CodeBlock className="language-html" title="template">
+{ vueSourceCode }
+  </CodeBlock>
+  <CodeBlock className="language-js" title="script">
+  {`import Flicking from "@egjs/vue-flicking";
+
+export default {
+    components: {
+        Flicking
+    }
+};`}
+  </CodeBlock></>
+  }
+  vue3={
+    <><CodeBlock className="language-html" title="template">
+{ vueSourceCode }
+  </CodeBlock>
+  <CodeBlock className="language-js" title="script">
+  {`import Flicking from "@egjs/vue3-flicking";
+
+export default {
+    components: {
+        Flicking
+    }
+};`}
+  </CodeBlock></>
+  }
+  angular={
+    <><CodeBlock className="language-html" title="app.component.html">
+{ angularSourceCode }
+  </CodeBlock>
+  <CodeBlock className="language-js" title="app.component.ts">
+  {`import { Component } from "@angular/core";
+import Flicking from "@egjs/ngx-flicking";
+
+@Component({
+  templateUrl: './demo.component.html'
+})
+export class DemoComponent {}`}
+  </CodeBlock></>
+  }
+  preact={
+    <CodeBlock className="language-jsx" title="DemoComponent.jsx">
+      { reactSourceCode }
+    </CodeBlock>
+  }
+  svelte={
+    <CodeBlock className="language-jsx" title="DemoComponent.jsx">
+      { svelteSourceCode }
+    </CodeBlock>
+  }
+/>
+  </>;
+};

--- a/docs/src/demo/Nested.tsx
+++ b/docs/src/demo/Nested.tsx
@@ -10,37 +10,24 @@ import Panel from "../component/Panel";
 
 export default () => {
   const vanillaHTML = `<div id="flick1" class="flicking-viewport">
+  <div className="flicking-panel">1</div>
   <div className="flicking-panel nested-wide">
     <div id="flick2" class="flicking-viewport">
-      <div className="flicking-panel nested-wide">
-        <div id="flick5" class="flicking-viewport vertical">
-          <div className="flicking-panel">1.09</div>
-          <div className="flicking-panel">1.1</div>
-          <div className="flicking-panel">1.11</div>
-        </div>
-      </div>
-      <div className="flicking-panel">1.2</div>
-      <div className="flicking-panel">1.3</div>
-    </div>
-  </div>
-  <div className="flicking-panel nested-wide">
-    <div id="flick3" class="flicking-viewport">
       <div className="flicking-panel">2.1</div>
       <div className="flicking-panel">2.2</div>
       <div className="flicking-panel">2.3</div>
     </div>
   </div>
-  <div className="flicking-panel nested-wide">
-    <div id="flick4" class="flicking-viewport">
+  <div className="flicking-panel nested-wide vertical">
+    <div id="flick3" class="flicking-viewport vertical">
       <div className="flicking-panel">3.1</div>
       <div className="flicking-panel">3.2</div>
       <div className="flicking-panel">3.3</div>
     </div>
   </div>
+  <div className="flicking-panel">4</div>
 </div>`;
-  const vanillaJS = `const flicking1 = new Flicking("#flick1", {
-  circular: true
-});
+  const vanillaJS = `const flicking1 = new Flicking("#flick1");
 const flicking2 = new Flicking("#flick2", {
   bounce: 0,
   bound: true,
@@ -49,36 +36,12 @@ const flicking2 = new Flicking("#flick2", {
 const flicking3 = new Flicking("#flick3", {
   bounce: 0,
   bound: true,
-  nested: true
-});
-const flicking4 = new Flicking("#flick4", {
-  bounce: 0,
-  bound: true,
-  nested: true
-});
-const flicking5 = new Flicking("#flick5", {
-  bounce: 0,
-  bound: true,
-  horizontal: false,
-  defaultIndex: 1,
-  circular: true
+  horizontal: false
 });`;
   const reactSourceCode = `export default () => {
     return <>
-      <Flicking circular={true}>
-        <div className="flicking-panel nested-wide">
-          <Flicking bounce="0" bound={true} nested={true}>
-            <div className="flicking-panel nested-wide">
-              <Flicking bounce="0" bound={true} horizontal={false} defaultIndex={1} circular={true}>
-                <div className="flicking-panel">1.09</div>
-                <div className="flicking-panel">1.1</div>
-                <div className="flicking-panel">1.11</div>
-              </Flicking>
-            </div>
-            <div className="flicking-panel">1.2</div>
-            <div className="flicking-panel">1.3</div>
-          </Flicking>
-        </div>
+      <Flicking>
+        <div className="flicking-panel">1</div>
         <div className="flicking-panel nested-wide">
           <Flicking bounce="0" bound={true} nested={true}>
             <div className="flicking-panel">2.1</div>
@@ -86,59 +49,37 @@ const flicking5 = new Flicking("#flick5", {
             <div className="flicking-panel">2.3</div>
           </Flicking>
         </div>
-        <div className="flicking-panel nested-wide">
-          <Flicking bounce="0" bound={true} nested={true}>
+        <div className="flicking-panel nested-wide vertical">
+          <Flicking bounce="0" bound={true} horizontal={false}>
             <div className="flicking-panel">3.1</div>
             <div className="flicking-panel">3.2</div>
             <div className="flicking-panel">3.3</div>
           </Flicking>
         </div>
+        <div className="flicking-panel">4</div>
       </Flicking>
     </>
   };`;
-  const angularSourceCode = `<ngx-flicking [options]="{ circular: true }">
-  <div flicking-panel class="nested-wide">
-    <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
-      <div flicking-panel class="nested-wide">
-        <ngx-flicking [options]="{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }">
-          <div flicking-panel>1.09</div>
-          <div flicking-panel>1.1</div>
-          <div flicking-panel>1.11</div>
-        </div>
-      </div>
-      <div flicking-panel>1.2</div>
-      <div flicking-panel>1.3</div>
-    </div>
-  </div>
+  const angularSourceCode = `<ngx-flicking>
+  <div flicking-panel>1</div>
   <div flicking-panel class="nested-wide">
     <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
       <div flicking-panel>2.1</div>
       <div flicking-panel>2.2</div>
       <div flicking-panel>2.3</div>
-    </div>
+    </ngx-flicking>
   </div>
-  <div flicking-panel class="nested-wide">
-    <ngx-flicking [options]="{ bounce: 0, bound: true, nested: true }">
+  <div flicking-panel class="nested-wide vertical">
+    <ngx-flicking [options]="{ bounce: 0, bound: true, horizontal: false }">
       <div flicking-panel>3.1</div>
       <div flicking-panel>3.2</div>
       <div flicking-panel>3.3</div>
-    </div>
+    </ngx-flicking>
   </div>
+  <div flicking-panel>4</div>
 </div>`;
-  const vueSourceCode = `<flicking :options="{ circular: true }">
-  <div class="flicking-panel nested-wide">
-    <flicking :options="{ bounce: 0, bound: true, nested: true }">
-      <div class="flicking-panel nested-wide">
-        <flicking :options="{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }">
-          <div class="flicking-panel">1.09</div>
-          <div class="flicking-panel">1.1</div>
-          <div class="flicking-panel">1.11</div>
-        </flicking>
-      </div>
-      <div class="flicking-panel">1.2</div>
-      <div class="flicking-panel">1.3</div>
-    </flicking>
-  </div>
+  const vueSourceCode = `<flicking>
+  <div class="flicking-panel">1</div>
   <div class="flicking-panel nested-wide">
     <flicking :options="{ bounce: 0, bound: true, nested: true }">
       <div class="flicking-panel">2.1</div>
@@ -146,32 +87,21 @@ const flicking5 = new Flicking("#flick5", {
       <div class="flicking-panel">2.3</div>
     </flicking>
   </div>
-  <div class="flicking-panel nested-wide">
-    <flicking :options="{ bounce: 0, bound: true, nested: true }">
+  <div class="flicking-panel nested-wide vertical">
+    <flicking :options="{ bounce: 0, bound: true, horizontal: false }">
       <div class="flicking-panel">3.1</div>
       <div class="flicking-panel">3.2</div>
       <div class="flicking-panel">3.3</div>
     </flicking>
   </div>
+  <div class="flicking-panel">4</div>
 </flicking>`;
   const svelteSourceCode = `<script lang="ts">
 import Flicking, { FlickingPanel } from "@egjs/svelte-flicking";
 </script>
 
-<Flicking options={{ circular: true }}>
-  <FlickingPanel class="nested-wide">
-    <Flicking options={{ bounce: 0, bound: true, nested: true }}>
-      <FlickingPanel class="nested-wide">
-        <Flicking options={{ bounce: 0, bound: true, horizontal: false, defaultIndex: 1, circular: true }}>
-          <FlickingPanel>1.09</FlickingPanel>
-          <FlickingPanel>1.1</FlickingPanel>
-          <FlickingPanel>1.11</FlickingPanel>
-        </Flicking>
-      </FlickingPanel>
-      <FlickingPanel>1.2</FlickingPanel>
-      <FlickingPanel>1.3</FlickingPanel>
-    </Flicking>
-  </FlickingPanel>
+<Flicking>
+  <FlickingPanel>1</FlickingPanel>
   <FlickingPanel class="nested-wide">
     <Flicking options={{ bounce: 0, bound: true, nested: true }}>
       <FlickingPanel>2.1</FlickingPanel>
@@ -179,30 +109,19 @@ import Flicking, { FlickingPanel } from "@egjs/svelte-flicking";
       <FlickingPanel>2.3</FlickingPanel>
     </Flicking>
   </FlickingPanel>
-  <FlickingPanel class="nested-wide">
-    <Flicking options={{ bounce: 0, bound: true, nested: true }}>
+  <FlickingPanel class="nested-wide vertical">
+    <Flicking options={{ bounce: 0, bound: true, horizontal: false }}>
       <FlickingPanel>3.1</FlickingPanel>
       <FlickingPanel>3.2</FlickingPanel>
       <FlickingPanel>3.3</FlickingPanel>
     </Flicking>
   </FlickingPanel>
+  <FlickingPanel>4</FlickingPanel>
 </Flicking>`;
 
   return <>
-    <Flicking className="py-4 mb-4" circular={true}>
-      <div className="flicking-panel nested-wide has-background-primary-dark">
-        <Flicking bounce="0" bound={true} nested={true}>
-          <div className="flicking-panel nested-wide">
-            <Flicking bounce="0" bound={true} horizontal={false} style={{ height: "140px" }} defaultIndex={1} circular={true}>
-              <Panel index={0.09} />
-              <Panel index={0.1} />
-              <Panel index={0.11} />
-            </Flicking>
-          </div>
-          <Panel index={0.2} />
-          <Panel index={0.3} />
-        </Flicking>
-      </div>
+    <Flicking className="py-4 mb-4">
+      <Panel index={0} />
       <div className="flicking-panel nested-wide has-background-primary-dark">
         <Flicking bounce="0" bound={true} nested={true}>
           <Panel index={1.1} />
@@ -210,13 +129,14 @@ import Flicking, { FlickingPanel } from "@egjs/svelte-flicking";
           <Panel index={1.3} />
         </Flicking>
       </div>
-      <div className="flicking-panel nested-wide has-background-primary-dark">
-        <Flicking bounce="0" bound={true} nested={true}>
+      <div className="flicking-panel nested-wide vertical has-background-primary-dark">
+        <Flicking bounce="0" bound={true} horizontal={false} style={{ height: "180px" }}>
           <Panel index={2.1} />
           <Panel index={2.2} />
           <Panel index={2.3} />
         </Flicking>
       </div>
+      <Panel index={3} />
     </Flicking>
     <SourceCode
       options={{ circular: true }} panels={[]}

--- a/docs/src/pages/Demos.mdx
+++ b/docs/src/pages/Demos.mdx
@@ -17,6 +17,9 @@ import Nested from "@site/src/demo/Nested";
 ## Panel add / remove
 <AddRemove />
 
+## Nested Flickings
+<Nested />
+
 ## Variable Size Panels
 Flicking uses panel element's real size, and doesn't modify them.
 <Flicking className="my-4" circular={true}>
@@ -47,6 +50,3 @@ Made with [@egjs/grid](https://github.com/naver/egjs-grid)
 
 ## Date Selector
 <DateSelector />
-
-## Nested Flickings
-<Nested />

--- a/docs/src/pages/Demos.mdx
+++ b/docs/src/pages/Demos.mdx
@@ -11,6 +11,7 @@ import Grid from "@site/src/demo/Grid";
 import WeatherDisplay from "@site/src/demo/WeatherDisplay";
 import DateSelector from "@site/src/demo/DateSelector";
 import LazyLoad from "@site/src/demo/LazyLoad";
+import Nested from "@site/src/demo/Nested";
 
 # Demos
 ## Panel add / remove
@@ -46,3 +47,6 @@ Made with [@egjs/grid](https://github.com/naver/egjs-grid)
 
 ## Date Selector
 <DateSelector />
+
+## Nested Flickings
+<Nested />

--- a/docs/src/pages/Options.mdx
+++ b/docs/src/pages/Options.mdx
@@ -456,6 +456,78 @@ This can be useful when you have contents inside Flicking that changes its size 
 You can't use `resizeOnContentsReady` when the `virtual` option is enabled
 :::
 
+### nested
+If you enable this option on child Flicking when the Flicking is placed inside the Flicking, the parent Flicking will move in the same direction after the child Flicking reaches the first/last panel.
+If the parent Flicking and child Flicking have different horizontal option, you do not need to set this option.
+
+<Columns>
+  <ColumnItem is={6}>
+
+  ```js
+  nested: false
+  ```
+
+  </ColumnItem>
+  <ColumnItem is={6}>
+    <Flicking>
+      <Panel index={0} />
+      <div className="flicking-panel nested has-background-primary-dark">
+        <Flicking bounce="0" bound={true} nested={false}>
+          <Panel className="is-size-3" index={1.1} />
+          <Panel className="is-size-3" index={1.2} />
+          <Panel className="is-size-3" index={1.3} />
+          <Panel className="is-size-3" index={1.4} />
+          <Panel className="is-size-3" index={1.5} />
+        </Flicking>
+      </div>
+      <div className="flicking-panel nested has-background-primary-dark">
+        <Flicking className="flicking-viewport vertical" bounce="0" bound={true} horizontal={false} style={{ height: "140px" }} nested={false}>
+          <Panel className="is-size-3" index={2.1} />
+          <Panel className="is-size-3" index={2.2} />
+          <Panel className="is-size-3" index={2.3} />
+          <Panel className="is-size-3" index={2.4} />
+          <Panel className="is-size-3" index={2.5} />
+        </Flicking>
+      </div>
+      <Panel index={3} />
+    </Flicking>
+  </ColumnItem>
+</Columns>
+
+<Columns>
+  <ColumnItem is={6}>
+
+  ```js
+  nested: true
+  ```
+
+  </ColumnItem>
+  <ColumnItem is={6}>
+    <Flicking nested={true}>
+      <Panel index={0} />
+      <div className="flicking-panel nested has-background-primary-dark">
+        <Flicking bounce="0" bound={true} nested={true}>
+          <Panel className="is-size-3" index={1.1} />
+          <Panel className="is-size-3" index={1.2} />
+          <Panel className="is-size-3" index={1.3} />
+          <Panel className="is-size-3" index={1.4} />
+          <Panel className="is-size-3" index={1.5} />
+        </Flicking>
+      </div>
+      <div className="flicking-panel nested has-background-primary-dark">
+        <Flicking className="flicking-viewport vertical" bounce="0" bound={true} horizontal={false} style={{ height: "140px" }} nested={true}>
+          <Panel className="is-size-3" index={2.1} />
+          <Panel className="is-size-3" index={2.2} />
+          <Panel className="is-size-3" index={2.3} />
+          <Panel className="is-size-3" index={2.4} />
+          <Panel className="is-size-3" index={2.5} />
+        </Flicking>
+      </div>
+      <Panel index={3} />
+    </Flicking>
+  </ColumnItem>
+</Columns>
+
 ## Event
 ### needPanelThreshold
 A Threshold from viewport edge before triggering **[needPanel](docs/api/Flicking#event-needPanel)** event

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.6.1",
+	"version": "4.6.2-snapshot",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@egjs/flicking",
-			"version": "4.6.1",
+			"version": "4.6.2-snapshot",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^2.8.0",
+				"@egjs/axes": "^3.1.2",
 				"@egjs/component": "^3.0.1",
 				"@egjs/imready": "^1.1.3",
 				"@egjs/list-differ": "^1.0.0"
@@ -1685,19 +1685,13 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-2.8.0.tgz",
-			"integrity": "sha512-WPMIM/ExZBS8guD3oeNr6YGDn2xSnj0YUZHWvY/NWvTQIs7A2O7WxJivYgzcg7r2q0RYtzrdpHn+982iaKCLSw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.1.2.tgz",
+			"integrity": "sha512-c3FkmSdTerP/TpFjOkuqN2GNQIQQMxiQHO4cqHH3yWQhMlWqNyUyX3H/gHumRNHtWxsiD++cnh73v9BVdN8tng==",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
-				"@egjs/component": "^2.2.2",
-				"@egjs/hammerjs": "^2.0.15"
+				"@egjs/component": "^3.0.1"
 			}
-		},
-		"node_modules/@egjs/axes/node_modules/@egjs/component": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@egjs/component/-/component-2.2.2.tgz",
-			"integrity": "sha512-2m6nu6/Mbs6VnoT4IHFGUBX6V82Zp01zDmlWpIJ3fMatHpe7BB1qUYFgMmSWGY0uOvOl4plvflwbCRUAGMfwWQ=="
 		},
 		"node_modules/@egjs/component": {
 			"version": "3.0.2",
@@ -1726,10 +1720,31 @@
 				"@egjs/flicking": "^4.1.0"
 			}
 		},
+		"node_modules/@egjs/flicking/node_modules/@egjs/axes": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-2.8.0.tgz",
+			"integrity": "sha512-WPMIM/ExZBS8guD3oeNr6YGDn2xSnj0YUZHWvY/NWvTQIs7A2O7WxJivYgzcg7r2q0RYtzrdpHn+982iaKCLSw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"@egjs/agent": "^2.2.1",
+				"@egjs/component": "^2.2.2",
+				"@egjs/hammerjs": "^2.0.15"
+			}
+		},
+		"node_modules/@egjs/flicking/node_modules/@egjs/axes/node_modules/@egjs/component": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@egjs/component/-/component-2.2.2.tgz",
+			"integrity": "sha512-2m6nu6/Mbs6VnoT4IHFGUBX6V82Zp01zDmlWpIJ3fMatHpe7BB1qUYFgMmSWGY0uOvOl4plvflwbCRUAGMfwWQ==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/@egjs/hammerjs": {
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
 			"integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/hammerjs": "^2.0.36"
 			},
@@ -2138,9 +2153,11 @@
 			}
 		},
 		"node_modules/@types/hammerjs": {
-			"version": "2.0.40",
-			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
-			"integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA=="
+			"version": "2.0.41",
+			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+			"integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.9",
@@ -17842,20 +17859,12 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"@egjs/axes": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-2.8.0.tgz",
-			"integrity": "sha512-WPMIM/ExZBS8guD3oeNr6YGDn2xSnj0YUZHWvY/NWvTQIs7A2O7WxJivYgzcg7r2q0RYtzrdpHn+982iaKCLSw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.1.2.tgz",
+			"integrity": "sha512-c3FkmSdTerP/TpFjOkuqN2GNQIQQMxiQHO4cqHH3yWQhMlWqNyUyX3H/gHumRNHtWxsiD++cnh73v9BVdN8tng==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
-				"@egjs/component": "^2.2.2",
-				"@egjs/hammerjs": "^2.0.15"
-			},
-			"dependencies": {
-				"@egjs/component": {
-					"version": "2.2.2",
-					"resolved": "https://registry.npmjs.org/@egjs/component/-/component-2.2.2.tgz",
-					"integrity": "sha512-2m6nu6/Mbs6VnoT4IHFGUBX6V82Zp01zDmlWpIJ3fMatHpe7BB1qUYFgMmSWGY0uOvOl4plvflwbCRUAGMfwWQ=="
-				}
+				"@egjs/component": "^3.0.1"
 			}
 		},
 		"@egjs/component": {
@@ -17874,6 +17883,29 @@
 				"@egjs/component": "^3.0.1",
 				"@egjs/imready": "^1.1.3",
 				"@egjs/list-differ": "^1.0.0"
+			},
+			"dependencies": {
+				"@egjs/axes": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-2.8.0.tgz",
+					"integrity": "sha512-WPMIM/ExZBS8guD3oeNr6YGDn2xSnj0YUZHWvY/NWvTQIs7A2O7WxJivYgzcg7r2q0RYtzrdpHn+982iaKCLSw==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"@egjs/agent": "^2.2.1",
+						"@egjs/component": "^2.2.2",
+						"@egjs/hammerjs": "^2.0.15"
+					},
+					"dependencies": {
+						"@egjs/component": {
+							"version": "2.2.2",
+							"resolved": "https://registry.npmjs.org/@egjs/component/-/component-2.2.2.tgz",
+							"integrity": "sha512-2m6nu6/Mbs6VnoT4IHFGUBX6V82Zp01zDmlWpIJ3fMatHpe7BB1qUYFgMmSWGY0uOvOl4plvflwbCRUAGMfwWQ==",
+							"dev": true,
+							"peer": true
+						}
+					}
+				}
 			}
 		},
 		"@egjs/flicking-plugins": {
@@ -17887,6 +17919,8 @@
 			"version": "2.0.17",
 			"resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
 			"integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/hammerjs": "^2.0.36"
 			}
@@ -18213,9 +18247,11 @@
 			}
 		},
 		"@types/hammerjs": {
-			"version": "2.0.40",
-			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.40.tgz",
-			"integrity": "sha512-VbjwR1fhsn2h2KXAY4oy1fm7dCxaKy0D+deTb8Ilc3Eo3rc5+5eA4rfYmZaHgNJKxVyI0f6WIXzO2zLkVmQPHA=="
+			"version": "2.0.41",
+			"resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
+			"integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA==",
+			"dev": true,
+			"peer": true
 		},
 		"@types/json-schema": {
 			"version": "7.0.9",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"demo:prebuild-version": "cpx 'dist/**/*' docs/build/release/$npm_package_version/dist --clean",
 		"demo:prebuild-latest": "cpx 'dist/**/*' docs/build/release/latest/dist --clean",
 		"demo:deploy": "npm run docs:release && npm run build && npm run demo:prebuild-version && npm run demo:prebuild-latest && gh-pages -d docs/build/ --add --remote upstream",
+		"demo:deploy-origin": "npm run docs:release && npm run build && npm run demo:prebuild-version && npm run demo:prebuild-latest && gh-pages -d docs/build/ --add --remote origin",
 		"release": "release-helper upstream",
 		"changelog": "node ./config/changelog.js",
 		"coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
@@ -135,7 +136,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^3.1.1",
+		"@egjs/axes": "^3.1.2",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^2.8.0",
+		"@egjs/axes": "^3.1.1",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -58,6 +58,7 @@ export interface FlickingOptions {
   panelsPerView: number;
   noPanelStyleOverride: boolean;
   resizeOnContentsReady: boolean;
+  nested: boolean;
 
   // EVENT
   needPanelThreshold: number;
@@ -136,6 +137,7 @@ class Flicking extends Component<FlickingEvents> {
   private _noPanelStyleOverride: FlickingOptions["noPanelStyleOverride"];
   private _resizeOnContentsReady: FlickingOptions["resizeOnContentsReady"];
   private _virtual: FlickingOptions["virtual"];
+  private _nested: FlickingOptions["nested"];
 
   private _needPanelThreshold: FlickingOptions["needPanelThreshold"];
   private _preventEventsBeforeInit: FlickingOptions["preventEventsBeforeInit"];
@@ -413,6 +415,15 @@ class Flicking extends Component<FlickingEvents> {
    * @default false
    */
   public get resizeOnContentsReady() { return this._resizeOnContentsReady; }
+  /**
+   * If you enable this option on child Flicking when the Flicking is placed inside the Flicking, the parent Flicking will move in the same direction after the child Flicking reaches the first/last panel.
+   * If the parent Flicking and child Flicking have different horizontal option, you do not need to set this option.
+   * @ko Flicking 내부에 Flicking이 배치될 때 하위 Flicking에서 이 옵션을 활성화하면 하위 Flicking이 첫/마지막 패널에 도달한 뒤부터 같은 방향으로 상위 Flicking이 움직입니다.
+   * 만약 상위 Flicking과 하위 Flicking이 서로 다른 horizontal 옵션을 가지고 있다면 이 옵션을 설정할 필요가 없습니다.
+   * @type {boolean}
+   * @default false
+   */
+  public get nested() { return this._nested; }
   // EVENTS
   /**
    * A Threshold from viewport edge before triggering `needPanel` event
@@ -677,6 +688,7 @@ class Flicking extends Component<FlickingEvents> {
   public set panelsPerView(val: FlickingOptions["panelsPerView"]) { this._panelsPerView = val; }
   public set noPanelStyleOverride(val: FlickingOptions["noPanelStyleOverride"]) { this._noPanelStyleOverride = val; }
   public set resizeOnContentsReady(val: FlickingOptions["resizeOnContentsReady"]) { this._resizeOnContentsReady = val; }
+  public set nested(val: FlickingOptions["nested"]) { this._nested = val; }
   // EVENTS
   public set needPanelThreshold(val: FlickingOptions["needPanelThreshold"]) { this._needPanelThreshold = val; }
   public set preventEventsBeforeInit(val: FlickingOptions["preventEventsBeforeInit"]) { this._preventEventsBeforeInit = val; }
@@ -768,6 +780,7 @@ class Flicking extends Component<FlickingEvents> {
     panelsPerView = -1,
     noPanelStyleOverride = false,
     resizeOnContentsReady = false,
+    nested = false,
     needPanelThreshold = 0,
     preventEventsBeforeInit = true,
     deceleration = 0.0075,
@@ -808,6 +821,7 @@ class Flicking extends Component<FlickingEvents> {
     this._panelsPerView = panelsPerView;
     this._noPanelStyleOverride = noPanelStyleOverride;
     this._resizeOnContentsReady = resizeOnContentsReady;
+    this._nested = nested;
     this._virtual = virtual;
     this._needPanelThreshold = needPanelThreshold;
     this._preventEventsBeforeInit = preventEventsBeforeInit;

--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -86,7 +86,7 @@ class AxesController {
    * @type {boolean}
    * @readonly
    */
-  public get enabled() { return this._panInput?.isEnable() ?? false; }
+  public get enabled() { return this._panInput?.isEnabled() ?? false; }
   /**
    * Current position value in {@link https://naver.github.io/egjs-axes/release/latest/doc/eg.Axes.html Axes} instance
    * @ko {@link https://naver.github.io/egjs-axes/release/latest/doc/eg.Axes.html Axes} 인스턴스 내부의 현재 좌표 값
@@ -134,6 +134,7 @@ class AxesController {
     }, {
       deceleration: flicking.deceleration,
       interruptable: flicking.interruptable,
+      nested: flicking.nested,
       easing: flicking.easing
     });
     this._panInput = new PanInput(flicking.viewport.element, {
@@ -220,7 +221,7 @@ class AxesController {
     axis.range = [controlParams.range.min, controlParams.range.max];
     axis.bounce = parseBounce(flicking.bounce, camera.size);
 
-    axes.axm.set({ [AXES.POSITION_KEY]: controlParams.position });
+    axes.axisManager.set({ [AXES.POSITION_KEY]: controlParams.position });
 
     return this;
   }
@@ -331,7 +332,7 @@ class AxesController {
         ? circulatePosition(position, camera.range.min, camera.range.max)
         : position;
 
-      axes.axm.set({ [AXES.POSITION_KEY]: newPos });
+      axes.axisManager.set({ [AXES.POSITION_KEY]: newPos });
 
       return Promise.resolve();
     } else {

--- a/test/cfc/common/jest.config.js
+++ b/test/cfc/common/jest.config.js
@@ -22,6 +22,7 @@ module.exports = {
     "^.+\\.tsx?$": "ts-jest"
   },
   globals: {
+    "ontouchstart": null,
     "ts-jest": {
       tsconfig: "<rootDir>/tsconfig.spec.json"
     }

--- a/test/cfc/common/simulate.ts
+++ b/test/cfc/common/simulate.ts
@@ -69,29 +69,21 @@ const loop = (ctx: {
   const isFirst = (loopCnt === 0);
   const isLast = (loopCnt === loops - 1);
 
-  const eventProps: Partial<MouseEvent> = {
-    x,
-    y,
+  const touches: Array<Partial<Touch>> = [{
     clientX: x,
     clientY: y,
-    offsetX: x,
-    offsetY: y,
     pageX: x,
     pageY: y,
     screenX: x,
-    screenY: y,
-    button: 0,
-    buttons: 1,
-    which: 1,
-    isTrusted: true
-  };
+    screenY: y
+  }];
 
   if (isFirst) {
-    fireEvent.mouseDown(element, eventProps);
+    fireEvent.touchStart(element, { touches });
   } else if (isLast) {
-    fireEvent.mouseUp(element, eventProps);
+    fireEvent.touchEnd(element);
   } else {
-    fireEvent.mouseMove(element, eventProps);
+    fireEvent.touchMove(element, { touches });
   }
 
   if (!isLast) {

--- a/test/manual/js/nested.js
+++ b/test/manual/js/nested.js
@@ -1,0 +1,13 @@
+const parentFlicking = new Flicking("#parent", {
+  moveType: "freeScroll"
+});
+const childFlicking = new Flicking("#child", {
+  moveType: "freeScroll",
+  bounce: 0,
+  bound: true,
+  nested: true
+});
+
+parentFlicking.on("willChange", evt => {
+  evt.stop();
+});

--- a/test/manual/nested.html
+++ b/test/manual/nested.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/es6-promise/dist/es6-promise.auto.js"></script>
+  <script type="text/javascript" src="../../dist/flicking.pkgd.js"></script>
+  <script type="text/javascript" src="../../node_modules/@egjs/flicking-plugins/dist/plugins.js"></script>
+  <link rel="stylesheet" href="./css/index.css">
+  <link rel="stylesheet" href="../../dist/flicking.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.2/css/bulma.min.css">
+  <title>Flicking Manual Test</title>
+</head>
+<body>
+  <div class="demo-area">
+    <div class="test"></div>
+    <!-- Basic -->
+    <div id="parent" class="flicking-viewport">
+      <div class="flicking-camera">
+        <div class="flicking-panel has-text-white has-background-primary">1</div>
+        <div class="flicking-panel has-text-white has-background-warning">2</div>
+        <div class="flicking-panel has-text-white has-background-danger">
+          <div id="child" class="flicking-viewport">
+            <div class="flicking-camera">
+              <div class="flicking-panel has-text-white has-background-primary">1</div>
+              <div class="flicking-panel has-text-white has-background-warning">2</div>
+              <div class="flicking-panel has-text-white has-background-danger">3</div>
+              <div class="flicking-panel has-text-white has-background-black">4</div>
+              <div class="flicking-panel has-text-white has-background-info">5</div>
+              <div class="flicking-panel has-text-white has-background-link">6</div>
+            </div>
+          </div>
+        </div>
+        <div class="flicking-panel has-text-white has-background-black">4</div>
+        <div class="flicking-panel has-text-white has-background-info">5</div>
+        <div class="flicking-panel has-text-white has-background-link">6</div>
+      </div>
+    </div>
+  </div>
+  <script type="text/javascript" src="./js/nested.js"></script>
+</body>
+</html>

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -254,6 +254,39 @@ describe("Flicking", () => {
       });
     });
 
+    describe("nested", () => {
+      it("is false by default", async () => {
+        const flicking = await createFlicking(El.DEFAULT_VERTICAL);
+
+        expect(flicking.nested).to.be.false;
+      });
+
+      [true, false].forEach(nested => {
+        it("should check index of two flickings when nested option is " + nested, async () => {
+          const nestedPanel = El.panel().setWidth("100%").setHeight(300).add(
+            El.camera().add(
+              El.panel().setWidth("100%").setHeight(300),
+              El.panel().setWidth("100%").setHeight(300),
+              El.panel().setWidth("100%").setHeight(300),
+            )
+          );
+          const parentFlicking = await createFlicking(El.viewport("500px", "100%").add(
+            El.camera().add(
+              El.panel().setWidth("100%").setHeight(300),
+              nestedPanel,
+              El.panel().setWidth("100%").setHeight(300),
+            ),
+          ));
+          const childFlicking = new Flicking(nestedPanel.el, { nested });
+
+          await simulate(nestedPanel.el, { deltaX: -2500 });
+
+          expect(childFlicking.index).equals(2);
+          expect(parentFlicking.index).equals(nested ? 2 : 0);
+        });
+      });
+    });
+
     describe("needPanelThreshold", () => {
       it("is 0 by default", async () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);


### PR DESCRIPTION
## Details
![nestedgrid](https://user-images.githubusercontent.com/13797320/167732283-ed01a965-4953-49fc-ba1f-8a06f20b549b.gif)

`nested` is added to `FlickingOptions` and you can define the movement of Flicking inside Flicking.

If `nested` is set to true, the parent Flicking will start moving if the child Flicking reaches the start/end of the panels.
If `nested` is set to false, parent Flicking does not move when user swipes child Flicking.

![nesteddemov2](https://user-images.githubusercontent.com/13797320/167732371-de828214-a709-4359-b308-87b8b682d44b.gif)
![nested2](https://user-images.githubusercontent.com/13797320/167732359-87659178-dc0f-4061-bb8c-b1450bfba9e5.gif)

Also added examples of nested option applied to Options page and Demos page of documentation.