### PR TITLE
fix: use appropriate touch-action for element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.6.2-snapshot",
+	"version": "4.7.0-snapshot",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@egjs/flicking",
-			"version": "4.6.2-snapshot",
+			"version": "4.7.0-snapshot",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^3.1.2",
+				"@egjs/axes": "^3.2.0",
 				"@egjs/component": "^3.0.1",
 				"@egjs/imready": "^1.1.3",
 				"@egjs/list-differ": "^1.0.0"
@@ -1685,9 +1685,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.1.2.tgz",
-			"integrity": "sha512-c3FkmSdTerP/TpFjOkuqN2GNQIQQMxiQHO4cqHH3yWQhMlWqNyUyX3H/gHumRNHtWxsiD++cnh73v9BVdN8tng==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.0.tgz",
+			"integrity": "sha512-PF4PlCbLPvbWlugzQ0pMQ00WMw52WHgPA+qHtMCWB3/+ZuJ5SZcyt61xvD0R9291N+dDLE2TBwpOsQGRqcoioQ==",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"
@@ -17859,9 +17859,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"@egjs/axes": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.1.2.tgz",
-			"integrity": "sha512-c3FkmSdTerP/TpFjOkuqN2GNQIQQMxiQHO4cqHH3yWQhMlWqNyUyX3H/gHumRNHtWxsiD++cnh73v9BVdN8tng==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.0.tgz",
+			"integrity": "sha512-PF4PlCbLPvbWlugzQ0pMQ00WMw52WHgPA+qHtMCWB3/+ZuJ5SZcyt61xvD0R9291N+dDLE2TBwpOsQGRqcoioQ==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^3.1.2",
+		"@egjs/axes": "^3.2.0",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"


### PR DESCRIPTION
## Issue
#673 

## Details
It uses the 3.2.0 version of the Axes and sets appropriate touch-action according to the drag direction of Flicking.
For horizontal flicking, touch-action is set to pan-y. And for vertical flicking, touch-action is set to pan-x.