### PR TITLE
fix: unable to drag, swipe in iOS Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.7.1-snapshot",
+	"version": "4.7.2-snapshot",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@egjs/flicking",
-			"version": "4.7.1-snapshot",
+			"version": "4.7.2-snapshot",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^3.2.1",
+				"@egjs/axes": "^3.2.2",
 				"@egjs/component": "^3.0.1",
 				"@egjs/imready": "^1.1.3",
 				"@egjs/list-differ": "^1.0.0"
@@ -1685,9 +1685,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.1.tgz",
-			"integrity": "sha512-RuTuYLG74yTHjbaNx/nvjlXs39e9lqpU8qrz5znSmP8xnNdJy+sTgOXWG2tpwv/6SQGKS3Ygze97bxPVJSy+nQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
+			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"
@@ -17859,9 +17859,9 @@
 			"integrity": "sha512-ENhwkOW6rnYW8IuXJwvECIAzj7nMxq+ctB8uCJ+mKnoKK8tGiv3YXtN6nuaOov2YmXdRdwafSz9rhgRNXswX/A=="
 		},
 		"@egjs/axes": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.1.tgz",
-			"integrity": "sha512-RuTuYLG74yTHjbaNx/nvjlXs39e9lqpU8qrz5znSmP8xnNdJy+sTgOXWG2tpwv/6SQGKS3Ygze97bxPVJSy+nQ==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
+			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.7.2",
+	"version": "4.7.2-snapshot",
 	"description": "Everyday 30 million people experience. It's reliable, flexible and extendable carousel.",
 	"main": "dist/flicking.js",
 	"module": "dist/flicking.esm.js",
@@ -136,7 +136,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^3.2.1",
+		"@egjs/axes": "^3.2.2",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"


### PR DESCRIPTION
## Issue
#677 

## Details
Fixed an error where drag gestures still didn't work on iOS, updating Axes to 3.2.2
[This is pre-release demo that resolved the problem that occurred in iOS.](https://malangfox.github.io/egjs-flicking/Demos) 