### PR TITLE
refactor: add union type to ViewportSlot

### DIFF
--- a/packages/react-flicking/src/react-flicking/ViewportSlot.tsx
+++ b/packages/react-flicking/src/react-flicking/ViewportSlot.tsx
@@ -4,6 +4,6 @@
  */
 import React from "react";
 
-const ViewportSlot = React.memo((props: { children?: React.ReactElement[] }) => <>{props.children}</>);
+const ViewportSlot = React.memo((props: { children?: React.ReactElement[] | React.ReactElement }) => <>{props.children}</>);
 
 export default ViewportSlot;

--- a/packages/react-flicking/src/react-flicking/ViewportSlot.tsx
+++ b/packages/react-flicking/src/react-flicking/ViewportSlot.tsx
@@ -2,8 +2,8 @@
  * Copyright (c) 2015 NAVER Corp.
  * egjs projects are licensed under the MIT license
  */
-import React from "react";
+import React, { ReactNode } from "react";
 
-const ViewportSlot = React.memo((props: { children?: React.ReactElement[] | React.ReactElement }) => <>{props.children}</>);
+const ViewportSlot = React.memo((props: { children?: ReactNode }) => <>{props.children}</>);
 
 export default ViewportSlot;


### PR DESCRIPTION
## Details
Sometimes ViewportSlot has only one children such as Plugin Pagination. 
So I think ViewportSlot children type must be React.ReactElement[] or React.ReactElement.

![image](https://user-images.githubusercontent.com/21374353/171793887-4e26ebf6-3c57-497e-a1a9-378bc401e639.png)
