### PR TITLE
fix: prevent click works even when input is disabled

### DIFF
--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -368,7 +368,7 @@ class AxesController {
   };
 
   private _onAxesChange = () => {
-    this._dragged = true;
+    this._dragged = !!this._panInput?.isEnabled() && true;
   };
 
   private _preventClickWhenDragged = (e: MouseEvent) => {

--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -368,7 +368,7 @@ class AxesController {
   };
 
   private _onAxesChange = () => {
-    this._dragged = !!this._panInput?.isEnabled() && true;
+    this._dragged = !!this._panInput?.isEnabled();
   };
 
   private _preventClickWhenDragged = (e: MouseEvent) => {

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -643,6 +643,20 @@ describe("Flicking", () => {
 
         expect(clickSpy.called).to.be.true;
       });
+
+      it("shouldn't bother click event when input is disabled", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { preventClickOnDrag: true });
+        const clickSpy = sinon.spy();
+        const testPanel = flicking.panels[0];
+
+        flicking.disableInput();
+        testPanel.element.addEventListener("click", clickSpy);
+
+        await simulate(flicking.element, { deltaX: -50, deltaY: 0 });
+        testPanel.element.click();
+
+        expect(clickSpy.called).to.be.true;
+      });
     });
 
     describe("changeOnHold", () => {


### PR DESCRIPTION
## Details
Fixed the issue that next click did not work when moving the Flicking using `moveTo` after `disableInput`.

`disableInput` disables PanInput, so setting `dragged` to `false` when `hold` is made in `PanInput` no longer occurs.
If coordinate change is made in Axes using `moveTo` while `PanInput` is disabled, `dragged` becomes `true`, but `hold` does not occur in PanInput at the next click.

[Example of onClick not working after using moveTo by button while input is disabled.](https://codepen.io/malangfox/pen/zYRawpb) To check this error, click a Panel once, and click Next button, and click a Panel.


Since `PanInput` is used in Flicking for dragging gesture, we should set `dragged` to `true` only when `PanInput` is enabled.

