### PR TITLE
fix: panelsPerView not working with adaptive

### DIFF
--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -494,17 +494,19 @@ abstract class Renderer {
     const panelSizeObj = flicking.horizontal
       ? { width: panelSize }
       : { height: panelSize };
-    const firstPanelSizeObj = {
-      size: panelSize,
-      height: referencePanel.height,
-      margin: referencePanel.margin
-    };
 
-    if (!flicking.noPanelStyleOverride) {
+    if (flicking.noPanelStyleOverride) {
+      const firstPanelSizeObj = {
+        size: panelSize,
+        height: referencePanel.height,
+        margin: referencePanel.margin
+      };
+      flicking.panels.forEach(panel => panel.resize(firstPanelSizeObj));
+    } else {
       this._strategy.updatePanelSizes(flicking, panelSizeObj);
+      flicking.panels.forEach(panel => panel.resize());
     }
 
-    flicking.panels.forEach(panel => panel.resize(firstPanelSizeObj));
   }
 
   protected _removeAllChildsFromCamera() {

--- a/test/manual/adaptive.html
+++ b/test/manual/adaptive.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<style>
+  * {
+    box-sizing: border-box;
+  }
+
+  #app {
+    font-family: "Avenir", Helvetica, Arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-align: center;
+    color: #2c3e50;
+    margin-top: 60px;
+    background: #F2F4F7;
+    width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .flicking-viewport {
+  transition: height 500ms;
+}
+  .panel {
+    background: #D7E6FF;
+    padding: 40px;
+    margin-right: 20px;
+  }
+
+.long {
+  height: 300px;
+}
+
+.short {
+  height: 150px;
+}
+
+.flicking-container {
+  padding: 10px 0;
+}
+
+</style>
+
+<head>
+  <meta name="viewport"
+    content="width=device-width,initial-scale=1.0,maximum-scale=1.0,minimum-scale=1.0,user-scalable=no">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <script type="text/javascript" src="../../dist/flicking.pkgd.js"></script>
+  <link rel="stylesheet" href="../../dist/flicking.css">
+  <title>Adaptive Flicking Test</title>
+</head>
+
+<body>
+  <div id="app">
+    <div class="flicking-container">
+      <div id="flicking" class="flicking-viewport">
+        <div class="flicking-camera">
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+          <div class="panel long">Long</div>
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+          <div class="panel short">Short</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+<script>
+const flicking = new Flicking("#flicking", {
+  bound: true,
+  panelsPerView: 3,
+  adaptive: true,
+});
+</script>
+</html>

--- a/test/unit/helper/El.ts
+++ b/test/unit/helper/El.ts
@@ -31,6 +31,29 @@ class El {
   }
 
   /**
+   * Horizontal Flicking using Panels with various heights
+   * @example
+   * - Viewport (width: 1000px, height: 100%)
+   *   - Camera
+   *     - Panel (width: 100%, height: 300px)
+   *     - Panel (width: 100%, height: 400px)
+   *     - Panel (width: 100%, height: 500px)
+   *     - Panel (width: 100%, height: 600px)
+   *     - Panel (width: 100%, height: 300px)
+   */
+  public static get VARIOUS_HORIZONTAL() {
+    return El.viewport("1000px", "100%").add(
+      El.camera().add(
+        El.panel().setWidth("100%").setHeight(300),
+        El.panel().setWidth("100%").setHeight(400),
+        El.panel().setWidth("100%").setHeight(500),
+        El.panel().setWidth("100%").setHeight(600),
+        El.panel().setWidth("100%").setHeight(300),
+      ),
+    );
+  }
+
+  /**
    * Very basic structure of the horizontal Flicking with n panels
    * @example
    * - Viewport (width: 1000px, height: 100%)

--- a/test/unit/renderer/Renderer.spec.ts
+++ b/test/unit/renderer/Renderer.spec.ts
@@ -316,6 +316,17 @@ describe("Renderer", () => {
         expect(panels.every(panel => panel.size === viewportSize)).to.be.true;
         expect(panels.every(panel => panel.element.style.width === "100px")).to.be.true;
       });
+
+      it("should not update the height of the horizontal panel by panelsPerView.", async () => {
+        const flicking = await createFlicking(El.VARIOUS_HORIZONTAL, { panelsPerView: 2 });
+        const renderer = new RendererImpl().init(flicking);
+        const panels = flicking.panels;
+        const expectedHeight = parseInt(flicking.panels[2].element.style.height, 10);
+
+        renderer.updatePanelSize();
+
+        expect(panels[2].height === expectedHeight).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
## Details
If you use the `panelsPerView` option in horizontal flicking, the height of all panels is also internally made to be the same as the first panel.

This causes invalid behavior at the `adaptive` option that resizes the viewport via the Panel’s height.

[Demo - adaptive option not working](https://codesandbox.io/s/adaptive-flicking-ilvxyr?file=/src/App.vue)

Also, when using the `bound` option with `panelsPerView`, the incorrectly calculated size will cause an error when moving the Panel.

[Demo - panelsPerView option causing error](https://codesandbox.io/s/panelsperview-flicking-error-k9ef7h?file=/src/App.vue)

This fixes both by modifying the behavior to resize all Panels instead of just the first one and using it for resizing all.
