### PR TITLE
fix: bound option causing error when using with specific panel width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.8.0",
+	"version": "4.9.0-snapshot",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@egjs/flicking",
-			"version": "4.8.0",
+			"version": "4.9.0-snapshot",
 			"license": "MIT",
 			"dependencies": {
-				"@egjs/axes": "^3.2.2",
+				"@egjs/axes": "^3.4.0",
 				"@egjs/component": "^3.0.1",
 				"@egjs/imready": "^1.1.3",
 				"@egjs/list-differ": "^1.0.0"
@@ -1732,9 +1732,9 @@
 			"integrity": "sha512-UZQzdpPl0g0M1wDAiq4EY2vUzUI6P5SKGOAPkf0yxSnlcwrU8/zuoyUWbYj11ROFeHV8iW0IetGsmia83z1Hbw=="
 		},
 		"node_modules/@egjs/axes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
-			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.4.0.tgz",
+			"integrity": "sha512-9XEbYOTPjROLJ9RYDms4JJjaJyrBZN1AWxdpKQqA6PN3lhDQtw6jdgY/e6tfY46L3nWPW5PLdo5woE7cY2sL9Q==",
 			"dependencies": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"
@@ -18290,9 +18290,9 @@
 			"integrity": "sha512-UZQzdpPl0g0M1wDAiq4EY2vUzUI6P5SKGOAPkf0yxSnlcwrU8/zuoyUWbYj11ROFeHV8iW0IetGsmia83z1Hbw=="
 		},
 		"@egjs/axes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.2.2.tgz",
-			"integrity": "sha512-1GKMQIHv/GYHPM6ccusyybmLOTA0nUMnRajiNjahVFdOcwglS9pUiYpo23MreVuLSUlQvjPWWHQP/LzGPNTTKA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@egjs/axes/-/axes-3.4.0.tgz",
+			"integrity": "sha512-9XEbYOTPjROLJ9RYDms4JJjaJyrBZN1AWxdpKQqA6PN3lhDQtw6jdgY/e6tfY46L3nWPW5PLdo5woE7cY2sL9Q==",
 			"requires": {
 				"@egjs/agent": "^2.2.1",
 				"@egjs/component": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"test": "npm run test --prefix test/unit",
 		"test:chrome": "npm run test:chrome --prefix test/unit",
 		"test:cfc": "npm run test --prefix test/cfc",
-		"lint": "eslint 'src/**/*.ts'",
+		"lint": "eslint src/**/*.ts",
 		"lint:test": "eslint 'test/unit/**/*.ts'",
 		"jsdoc": "jsdoc -c jsdoc.json",
 		"jsdoc:watch": "npm-watch jsdoc",
@@ -136,7 +136,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^3.2.2",
+		"@egjs/axes": "^3.4.0",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1502,11 +1502,12 @@ class Flicking extends Component<FlickingEvents> {
     const renderer = this._renderer;
     const control = this._control;
     const camera = this._camera;
-    const initialPanel = renderer.getPanel(this._defaultIndex) || renderer.getPanel(0);
+    const defaultPanel = renderer.getPanel(this._defaultIndex) || renderer.getPanel(0);
 
-    if (!initialPanel) return;
+    if (!defaultPanel) return;
 
-    const nearestAnchor = camera.findNearestAnchor(initialPanel.position);
+    const nearestAnchor = camera.findNearestAnchor(defaultPanel.position);
+    const initialPanel = (nearestAnchor && defaultPanel.index !== nearestAnchor?.panel.index) ? nearestAnchor.panel : defaultPanel;
     control.setActive(initialPanel, null, false);
 
     if (!nearestAnchor) {

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1507,7 +1507,7 @@ class Flicking extends Component<FlickingEvents> {
     if (!defaultPanel) return;
 
     const nearestAnchor = camera.findNearestAnchor(defaultPanel.position);
-    const initialPanel = (nearestAnchor && defaultPanel.index !== nearestAnchor?.panel.index) ? nearestAnchor.panel : defaultPanel;
+    const initialPanel = (nearestAnchor && defaultPanel.index !== nearestAnchor.panel.index) ? nearestAnchor.panel : defaultPanel;
     control.setActive(initialPanel, null, false);
 
     if (!nearestAnchor) {

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -71,7 +71,29 @@ describe("Flicking", () => {
       );
 
       expect(flicking.currentPanel).not.to.be.null;
-      expect(flicking.currentPanel).to.equal(flicking.getPanel(0));
+      expect(flicking.currentPanel).to.equal(flicking.camera.findNearestAnchor(0).panel);
+    });
+
+    [15, 30, 50, 100].forEach((width) => {
+      it(`should set current panel same as the panel at the initial anchor point (each panel width: ${width}%)`, async () => {
+        const flicking = await createFlicking(
+          El.viewport().add(
+            El.camera()
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+              .add(El.panel(`${width}%`))
+          ), {
+            bound: true // when bound is true, the number of anchors may be less than the number of panels
+          }
+        );
+
+        expect(flicking.currentPanel).to.equal(flicking.camera.findNearestAnchor(0).panel);
+        expect(flicking.currentPanel).to.equal(flicking.camera.anchorPoints[0].panel);
+      });
     });
   });
 


### PR DESCRIPTION
## Issue
#702 

## Details
When the width of each panel is less than 33% of the viewport, using the SnapControl and `bound` options together will cause an error.

We use [`findActiveAnchor`](https://github.com/naver/egjs-flicking/blob/master/src/camera/Camera.ts#L394-L399) in `moveToPosition` of SnapControl.
However ` find(this._anchors, anchor => anchor.panel.index === activeIndex)` can return `null` depending on the panel index of the anchors. This throws `POSITION_NOT_REACHABLE` error that makes SnapControl not working.

By default, [Flicking's `defaultIndex` is 0.](https://github.com/naver/egjs-flicking/blob/master/src/Flicking.ts#L799)  Also Flicking [sets the initial panel](https://github.com/naver/egjs-flicking/blob/master/src/Flicking.ts#L1505) to this 0th panel.
When the width of each panel is less than 33% of the viewport, the anchor with the 0th panel may not exist.

![image](https://user-images.githubusercontent.com/13797320/177907342-7c39cade-3ffd-41c9-8941-6698a389a181.png)

This makes the center of the viewport to the anchor of the 0th Panel. This situation does not reproduce an error.

![image](https://user-images.githubusercontent.com/13797320/177907333-6ab971ac-ef4d-42a7-9928-42346d5e25f1.png)

This makes the center of the viewport to the anchor of the first Panel. This situation causes error because the panel with the first anchor point has an index of 1, so there is no anchor with the 0th panel.

The 0th panel may never be selected depending on the width of the panels. We should apply this situation to Flicking's initialization process as well.

This changes `initialPanel` if the Panel index of the `nearestAnchor` is different from the index of the `initialPanel` when Flicking is initialized.


