### PR TITLE
fix: fix error when onChange occur during holding state

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
 		"typescript-transform-paths": "^2.2.3"
 	},
 	"dependencies": {
-		"@egjs/axes": "^3.4.0",
+		"@egjs/axes": "^3.6.0",
 		"@egjs/component": "^3.0.1",
 		"@egjs/imready": "^1.1.3",
 		"@egjs/list-differ": "^1.0.0"

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1084,6 +1084,10 @@ class Flicking extends Component<FlickingEvents> {
       return Promise.reject(new FlickingError(ERROR.MESSAGE.ANIMATION_ALREADY_PLAYING, ERROR.CODE.ANIMATION_ALREADY_PLAYING));
     }
 
+    if (this._control.holding) {
+      this._control.controller.release();
+    }
+
     return this._control.moveToPanel(panel, {
       duration,
       direction

--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -203,6 +203,18 @@ class AxesController {
   }
 
   /**
+   * Releases ongoing user input (mouse/touch)
+   * @ko 사용자의 현재 입력(마우스/터치)를 중단시킵니다
+   * @chainable
+   * @return {this}
+   */
+  public release(): this {
+    this._panInput?.release();
+
+    return this;
+  }
+
+  /**
    * Update {@link https://naver.github.io/egjs-axes/ @egjs/axes}'s state
    * @ko {@link https://naver.github.io/egjs-axes/ @egjs/axes}의 상태를 갱신합니다
    * @chainable

--- a/src/control/Control.ts
+++ b/src/control/Control.ts
@@ -162,6 +162,18 @@ abstract class Control {
   }
 
   /**
+   * Releases ongoing user input (mouse/touch)
+   * @ko 사용자의 현재 입력(마우스/터치)를 중단시킵니다
+   * @chainable
+   * @return {this}
+   */
+  public release(): this {
+    this._controller.release();
+
+    return this;
+  }
+
+  /**
    * Update position after resizing
    * @ko resize 이후에 position을 업데이트합니다
    * @param {number} progressInPanel Previous camera's progress in active panel before resize<ko>Resize 이전 현재 선택된 패널 내에서의 카메라 progress 값</ko>

--- a/src/control/states/HoldingState.ts
+++ b/src/control/states/HoldingState.ts
@@ -36,14 +36,17 @@ class HoldingState extends State {
 
   public onChange(ctx: Parameters<State["onChange"]>[0]): void {
     const { flicking, axesEvent, transitTo } = ctx;
-    const animatingContext = flicking.control.controller.animatingContext;
+
     const inputEvent = axesEvent.inputEvent as { offsetX: number; offsetY: number };
-    const offset = flicking.horizontal ? inputEvent?.offsetX : inputEvent?.offsetY;
+
+    const offset = flicking.horizontal
+      ? inputEvent.offsetX
+      : inputEvent.offsetY;
 
     const moveStartEvent = new ComponentEvent(EVENTS.MOVE_START, {
       isTrusted: axesEvent.isTrusted,
       holding: this.holding,
-      direction: inputEvent ? getDirection(0, -offset) : getDirection(animatingContext.start, animatingContext.end),
+      direction: getDirection(0, -offset),
       axesEvent
     });
     flicking.trigger(moveStartEvent);

--- a/src/control/states/HoldingState.ts
+++ b/src/control/states/HoldingState.ts
@@ -39,9 +39,11 @@ class HoldingState extends State {
 
     const inputEvent = axesEvent.inputEvent as { offsetX: number; offsetY: number };
 
-    const offset = flicking.horizontal
-      ? inputEvent.offsetX
-      : inputEvent.offsetY;
+    const offset = inputEvent
+      ? flicking.horizontal
+        ? inputEvent.offsetX
+        : inputEvent.offsetY
+      : 0;
 
     const moveStartEvent = new ComponentEvent(EVENTS.MOVE_START, {
       isTrusted: axesEvent.isTrusted,

--- a/src/control/states/HoldingState.ts
+++ b/src/control/states/HoldingState.ts
@@ -36,19 +36,14 @@ class HoldingState extends State {
 
   public onChange(ctx: Parameters<State["onChange"]>[0]): void {
     const { flicking, axesEvent, transitTo } = ctx;
-
+    const animatingContext = flicking.control.controller.animatingContext;
     const inputEvent = axesEvent.inputEvent as { offsetX: number; offsetY: number };
-
-    const offset = inputEvent
-      ? flicking.horizontal
-        ? inputEvent.offsetX
-        : inputEvent.offsetY
-      : 0;
+    const offset = flicking.horizontal ? inputEvent?.offsetX : inputEvent?.offsetY;
 
     const moveStartEvent = new ComponentEvent(EVENTS.MOVE_START, {
       isTrusted: axesEvent.isTrusted,
       holding: this.holding,
-      direction: getDirection(0, -offset),
+      direction: inputEvent ? getDirection(0, -offset) : getDirection(animatingContext.start, animatingContext.end),
       axesEvent
     });
     flicking.trigger(moveStartEvent);

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -1670,7 +1670,7 @@ describe("Flicking", () => {
         expect(flicking.camera.position).to.equal(flicking.panels[2].position);
       });
 
-      it("should determine direction with the animatingContext instead of the native event when onChange occurs by moveTo while holding", async () => {
+      it("can move to the panel when user input is holding", async () => {
         const flicking = await createFlicking(El.VARIOUS_HORIZONTAL, { moveType: "strict" });
 
         flicking.element.dispatchEvent(new TouchEvent("touchstart", {
@@ -1682,15 +1682,10 @@ describe("Flicking", () => {
           ],
           cancelable: true
         }));
-        const directions = [];
-
-        flicking.on(EVENTS.MOVE_START, evt => {
-          directions.push(evt.direction);
-        });
 
         await moveTo(flicking, 3);
 
-        expect(directions[0]).to.equal(DIRECTION.NEXT);
+        expect(flicking.index).to.equal(3);
       });
     });
 

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -1669,6 +1669,29 @@ describe("Flicking", () => {
         expect(flicking.index).to.equal(2);
         expect(flicking.camera.position).to.equal(flicking.panels[2].position);
       });
+
+      it("should determine direction with the animatingContext instead of the native event when onChange occurs by moveTo while holding", async () => {
+        const flicking = await createFlicking(El.VARIOUS_HORIZONTAL, { moveType: "strict" });
+
+        flicking.element.dispatchEvent(new TouchEvent("touchstart", {
+          touches: [
+            new Touch({
+              target: flicking.element,
+              identifier: Date.now()
+            })
+          ],
+          cancelable: true
+        }));
+        const directions = [];
+
+        flicking.on(EVENTS.MOVE_START, evt => {
+          directions.push(evt.direction);
+        });
+
+        await moveTo(flicking, 3);
+
+        expect(directions[0]).to.equal(DIRECTION.NEXT);
+      });
     });
 
     describe("getStatus()", () => {

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -1672,6 +1672,10 @@ describe("Flicking", () => {
 
       it("can move to the panel when user input is holding", async () => {
         const flicking = await createFlicking(El.VARIOUS_HORIZONTAL, { moveType: "strict" });
+        const holdStartSpy = sinon.spy();
+        const holdEndSpy = sinon.spy();
+        flicking.on(EVENTS.HOLD_START, holdStartSpy);
+        flicking.on(EVENTS.HOLD_END, holdEndSpy);
 
         flicking.element.dispatchEvent(new TouchEvent("touchstart", {
           touches: [
@@ -1685,6 +1689,8 @@ describe("Flicking", () => {
 
         await moveTo(flicking, 3);
 
+        expect(holdStartSpy.calledOnce).to.be.true;
+        expect(holdEndSpy.calledOnce).to.be.true;
         expect(flicking.index).to.equal(3);
       });
     });

--- a/test/unit/control/Control.spec.ts
+++ b/test/unit/control/Control.spec.ts
@@ -102,6 +102,18 @@ describe("Control", () => {
       });
     });
 
+    describe("release", () => {
+      it("should call release of the controller", () => {
+        const control = new ControlImpl();
+        const releaseSpy = sinon.spy();
+
+        control.controller.release = releaseSpy;
+        control.release();
+
+        expect(releaseSpy.calledOnce).to.be.true;
+      });
+    });
+
     describe("updateInput", () => {
       it("should call update of the controller", async () => {
         const control = new ControlImpl();


### PR DESCRIPTION
## Issue
#709 

## Details
If `onChange` occurs while Flicking is in the holding state, we check the `offsetX` or `offsetY` of the native event that caused the change.
```ts
    const inputEvent = axesEvent.inputEvent as { offsetX: number; offsetY: number };
    const offset = flicking.horizontal
      ? inputEvent.offsetX
      : inputEvent.offsetY;
```

However, there is no native event when we try to move the holding state Flicking using the method like `moveTo`. This will cause an error `Cannot read properties of null (reading 'offsetX')`.
[You can check the error in this demo.](https://codepen.io/malangfox/pen/NWYvQKW)

This changes `onChange` to check the direction using `animatingContext` instead of the native event when Flicking moves in a way other than a native event.