### PR TITLE
fix: add css files to sideEffects field of all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"description": "Everyday 30 million people experience. It's reliable, flexible and extendable carousel.",
 	"main": "dist/flicking.js",
 	"module": "dist/flicking.esm.js",
-	"sideEffects": false,
+	"sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
 	"es2015": "dist/flicking.esm.js",
 	"types": "declaration/index.d.ts",
 	"scripts": {

--- a/packages/preact-flicking/package.json
+++ b/packages/preact-flicking/package.json
@@ -4,7 +4,10 @@
   "description": "Everyday 30 million people experience. It's reliable, flexible and extendable carousel.",
   "main": "./dist/flicking.cjs.js",
   "module": "./dist/flicking.esm.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
   "types": "declaration/index.d.ts",
   "es2015": "dist/flicking.esm.js",
   "scripts": {

--- a/packages/react-flicking/package.json
+++ b/packages/react-flicking/package.json
@@ -4,7 +4,10 @@
   "description": "Everyday 30 million people experience. It's reliable, flexible and extendable carousel.",
   "main": "dist/flicking.cjs.js",
   "module": "dist/flicking.esm.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
   "es2015": "dist/flicking.esm.js",
   "types": "declaration/index.d.ts",
   "scripts": {

--- a/packages/svelte-flicking/package.json
+++ b/packages/svelte-flicking/package.json
@@ -4,7 +4,10 @@
   "description": "Everyday 30 million people experience. It's reliable, flexible and extendable carousel.",
   "main": "dist/flicking.cjs.js",
   "module": "dist/flicking.esm.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
   "es2015": "dist/flicking.esm.js",
   "types": "declaration/index.d.ts",
   "svelte": "lib/index.js",

--- a/packages/vue-flicking/package.json
+++ b/packages/vue-flicking/package.json
@@ -5,7 +5,10 @@
   "main": "dist/flicking.cjs.js",
   "module": "dist/flicking.esm.js",
   "types": "declaration/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
   "scripts": {
     "start": "vue-cli-service demo",
     "build": "rm -rf dist && rollup -c && npm run declaration",

--- a/packages/vue3-flicking/package.json
+++ b/packages/vue3-flicking/package.json
@@ -5,7 +5,10 @@
   "main": "dist/flicking.cjs.js",
   "module": "dist/flicking.esm.js",
   "types": "declaration/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.sass"
+  ],
   "scripts": {
     "start": "vue-cli-service serve ./demo/main.ts",
     "build": "rm -rf dist && rollup -c && npm run declaration",


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
fixes https://github.com/naver/egjs-flicking/issues/708, https://github.com/naver/egjs-flicking/issues/573

## Details
### 이슈 재현 
<!-- Detailed description of the change/feature -->
이슈는 nuxt + production 환경일 때 flicking.css파일이 사라진다는 내용입니다.
제 개발 환경이 react + 자체 ssr + production 환경임에도 해당 현상이 재현되어 공통점을 찾아보았습니다.

webpack@4
production 환경에서만 MiniCssExtractPlugin(webpack@4 호환 1.6.2), OptimizeCSSAssetsPlugin이 적용되어있습니다. 이 경우 재현이 가능한것으로 보입니다.
develop 환경에서는 style-loader를 사용하고 있습니다.

### 해결 방법
eg-js/flicking은 v4로 버전업 되면서 dist의 css 파일을 import해 사용하는 방식으로 변경되었습니다.
그러나 package.json의 sideEffects가 css파일을 별도로 제공하지 않을때 기준 그대로 false로 적용되어있습니다.
이 부분을 변경해주면 Flicking.css가 MiniCssExtractPlugin 1.6.2에서도 사라지지 않는것을 확인할 수 있습니다.

임시 해결방법으로는 아래 내용을 이용할 수 있습니다.
[Webpack - Mark the file as side-effect-free](https://webpack.kr/guides/tree-shaking/#mark-the-file-as-side-effect-free)
```
마지막으로 "sideEffects"는 [module.rules 옵션](https://webpack.kr/configuration/module/#modulerules)으로도 설정할 수 있습니다.
```
우선 저는 제 개발환경에 아래 임시 방편을 적용해둘 예정입니다.





이 pr은 정확한 원인을 찾지 못하고 표면적인 현상만 수정했기 때문에 closed 되어도 무관합니다.