### PR TITLE
fix: fix updated state not applied in event handler functions in React

### DIFF
--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -198,7 +198,6 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
 
   private _bindEvents() {
     const flicking = this._vanillaFlicking!;
-    const props = this.props as Required<FlickingProps>;
 
     Object.keys(EVENTS).forEach((eventKey: keyof typeof EVENTS) => {
       const eventName = EVENTS[eventKey];
@@ -207,7 +206,10 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
       flicking.on(eventName, e => {
         e.currentTarget = this;
 
-        props[propName](e);
+        const evtHandler = this.props[propName];
+        if (evtHandler) {
+          evtHandler(e);
+        }
       });
     });
 

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -207,9 +207,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
         e.currentTarget = this;
 
         const evtHandler = this.props[propName];
-        if (evtHandler) {
-          evtHandler(e);
-        }
+        evtHandler(e);
       });
     });
 


### PR DESCRIPTION
## Issue
#716 

## Details
This fixes the error that the event handler registered in react-flicking does not applies the updated state.
If we use the state declared be `useState` inside the event handler, the most recently updated state is not reflected correctly.

[In this demo, you can compare the results when adding a log by pressing a button and executing the same function as an event handler by moving Flicking.](https://codesandbox.io/s/egjs-flicking-v4-on-move-end-891kwx)
If this same function `holdStart` is executed as an event handler for Flicking, logs are recognized as an empty array in its initial state and the array will become empty.

This has been fixed by using event handlers with the correct scope.