### PR TITLE
fix: fix error when in exception when change occur without native event

### DIFF
--- a/src/control/states/HoldingState.ts
+++ b/src/control/states/HoldingState.ts
@@ -36,17 +36,15 @@ class HoldingState extends State {
 
   public onChange(ctx: Parameters<State["onChange"]>[0]): void {
     const { flicking, axesEvent, transitTo } = ctx;
-
+    const animatingContext = flicking.control.controller.animatingContext;
     const inputEvent = axesEvent.inputEvent as { offsetX: number; offsetY: number };
+    const offset = flicking.horizontal ? inputEvent?.offsetX : inputEvent?.offsetY;
 
-    const offset = flicking.horizontal
-      ? inputEvent.offsetX
-      : inputEvent.offsetY;
 
     const moveStartEvent = new ComponentEvent(EVENTS.MOVE_START, {
       isTrusted: axesEvent.isTrusted,
       holding: this.holding,
-      direction: getDirection(0, -offset),
+      direction: inputEvent ? getDirection(0, -offset) : getDirection(animatingContext.start, animatingContext.end),
       axesEvent
     });
     flicking.trigger(moveStartEvent);

--- a/test/unit/helper/test-util.ts
+++ b/test/unit/helper/test-util.ts
@@ -85,6 +85,18 @@ export const simulate = (el: HTMLElement, option: Partial<{
   })
 );
 
+export const dispatchTouchStart = (el: HTMLElement) => {
+  el.dispatchEvent(new TouchEvent("touchstart", {
+    touches: [
+      new Touch({
+        target: el,
+        identifier: Date.now()
+      })
+    ],
+    cancelable: true
+  }));
+};
+
 export const waitEvent = (emitter: any, eventName: string) => {
   if (emitter.once) {
     return new Promise(res => {


### PR DESCRIPTION
## Issue
#711 , https://github.com/naver/egjs-axes/issues/197

## Details
We previously checked an error that occurred because the native event did not exist when useing `moveTo` method fires the change event in the `HOLDING` state.
However, in addition to this case, it seems that the change event without native event while in the `HOLDING` state may occur.

This case is uncommon, but using some ways such as calling `setTo` on the Axes instance other than using Flicking's `moveTo` can be this case. This also add this case in our unit tests.

In other unexpected cases may exist while in `HOLDING` state. For this reason, when there is no native event, the direction is determined from the `animatingContext`.