### PR TITLE
fix: type cannot be compared

### DIFF
--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -304,7 +304,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
 
   private _isFragment(child: React.ReactElement) {
     if (child.type) {
-      return child.type === React.Fragment;
+      return child.type === typeof React.Fragment;
     }
 
     return (child as any) === React.Fragment;


### PR DESCRIPTION
## Issue
https://github.com/naver/egjs-flicking/issues/723

## Details

[`Flicking.tsx` > `_isFragment`](https://github.com/naver/egjs-flicking/blob/master/packages/react-flicking/src/react-flicking/Flicking.tsx)

<img width="464" alt="스크린샷 2022-08-24 오후 7 08 18" src="https://user-images.githubusercontent.com/106229475/186392112-5eee655f-cf46-4205-95f2-d205d355c495.png">

It doesn't compare the types of `child` and `React.Fragment`. on line 307.
