### PR TITLE
feat: add renderOnSamekey for react-flicking

### DIFF
--- a/docs/docs/tutorials/quick-start.mdx
+++ b/docs/docs/tutorials/quick-start.mdx
@@ -91,6 +91,15 @@ export default () => (
 )
 ```
 
+<h3>React exclusive options</h3>
+
+- viewportTag: HTML tag for `.flicking-viewport` element. (default: **"div"**)
+- cameraTag: HTML tag for `.flicking-camera` element. (default: **"div"**)
+- cameraClass: `className` for `.flicking-camera` element. (default: **""**)
+- renderOnSameKey: Whether to always render children even they have the same keys (default: **false**)
+  - Flicking doesn't rerender when children have same length & keys for performance by default.
+  - If you have to bypass this behavior, like when you have to update panel's innerHTML without changing the list of child elements, you can either set this option to `true`, or you can call Flicking component's `forceUpdate()`.
+
 <h3>Using the components as a panel</h3>
 
 If you're using the React Component as a panel, it should use a [ref forwarding](https://reactjs.org/docs/forwarding-refs.html)

--- a/packages/react-flicking/README.md
+++ b/packages/react-flicking/README.md
@@ -42,20 +42,29 @@ npm install --save @egjs/react-flicking
 import Flicking, { MoveEvent, WillChangeEvent } from "@egjs/react-flicking";
 
 <Flicking
-  viewportTag = "div"
-  cameraTag = "div"
-  cameraClass = ""
-  align = "center"
-  onMove = {(e: MoveEvent) => {}}
-  onWillChange = {(e: WillChangeEvent) => {}}
-  horizontal = {true}
-  circular = {true}
+  viewportTag="div"
+  cameraTag="div"
+  cameraClass=""
+  renderOnSameKey={false}
+  align="center"
+  onMove={(e: MoveEvent) => {}}
+  onWillChange={(e: WillChangeEvent) => {}}
+  horizontal={true}
+  circular={true}
 >
   <div>panel 0</div>
   <div>panel 1</div>
   <div>panel 2</div>
 </Flicking>
 ```
+
+## ✨ React exclusive options
+- viewportTag: HTML tag for `.flicking-viewport` element. (default: **"div"**)
+- cameraTag: HTML tag for `.flicking-camera` element. (default: **"div"**)
+- cameraClass: `className` for `.flicking-camera` element. (default: **""**)
+- renderOnSameKey: Whether to always render children even they have the same keys (default: **false**)
+  - Flicking doesn't rerender when children have same length & keys for performance by default.
+  - If you have to bypass this behavior, like when you have to update panel's innerHTML without changing the list of child elements, you can either set this option to `true`, or you can call Flicking component's `forceUpdate()`.
 
 ## 📦 Packages
 You can use all plugins just like native @egjs/flicking.

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -103,7 +103,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     }
 
     const prevChildren = this._prevChildren;
-    const nextChildren = this._getChildren(nextProps.children);
+    const nextChildren = this._getChildren(children);
     if (nextProps.renderOnSameKey || !this._hasSameChildren(prevChildren, nextChildren)) return true;
 
     return false;

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -36,7 +36,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
   private _viewportElement: HTMLElement;
   private _diffResult: DiffResult<React.ReactElement> | null;
   private _renderEmitter = new Component<{ render: void }>();
-  private _prevProps: Partial<FlickingProps & FlickingOptions>;
+  private _prevChildren: React.ReactElement[];
 
   public get reactPanels() { return this._panels.map(panel => panel.current!); }
   public get renderEmitter() { return this._renderEmitter; }
@@ -44,8 +44,9 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
   public constructor(props: Partial<FlickingProps & FlickingOptions>) {
     super(props);
 
-    this._panels = this._createPanelRefs(props, this._getChildren());
-    this._prevProps = this.props;
+    const children = this._getChildren();
+    this._panels = this._createPanelRefs(props, children);
+    this._prevChildren = children;
   }
 
   public componentDidMount() {
@@ -73,7 +74,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     const children = this._getChildren();
     this._jsxDiffer = new ListDiffer(children, panel => panel.key!);
     this._pluginsDiffer = new ListDiffer<any>();
-    this._prevProps = this.props;
+    this._prevChildren = children;
 
     this._bindEvents();
     this._checkPlugins();
@@ -92,7 +93,6 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     const prevProps = this.props;
 
     if (!vanillaFlicking || !vanillaFlicking.initialized) return false;
-    if (!this._hasSameChildren(prevProps, nextProps)) return true;
 
     const { children, ...restProps } = nextProps;
 
@@ -102,22 +102,26 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
       }
     }
 
+    const prevChildren = this._prevChildren;
+    const nextChildren = this._getChildren(nextProps.children);
+    if (nextProps.renderOnSameKey || !this._hasSameChildren(prevChildren, nextChildren)) return true;
+
     return false;
   }
 
   public beforeRender() {
     const vanillaFlicking = this._vanillaFlicking;
-    const nextProps = this.props;
-    const prevProps = this._prevProps;
+    const props = this.props;
+    const prevChildren = this._prevChildren;
 
     // Ignore updates before init, they will be updated after "ready" event's force update
     if (!vanillaFlicking || !vanillaFlicking.initialized) return;
 
-    if (!this._hasSameChildren(prevProps, nextProps)) {
-      const nextChildren = this._getChildren(nextProps.children);
-
-      this._panels = this._createPanelRefs(nextProps, nextChildren);
+    const nextChildren = this._getChildren(props.children);
+    if (props.renderOnSameKey || !this._hasSameChildren(prevChildren, nextChildren)) {
+      this._panels = this._createPanelRefs(props, nextChildren);
       this._diffResult = this._jsxDiffer.update(nextChildren);
+      this._prevChildren = nextChildren;
     }
   }
 
@@ -182,8 +186,6 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
       ? this._getVirtualPanels()
       : this._getPanels();
 
-    this._prevProps = props;
-
     return (
       <Viewport {...attributes} className={viewportClasses.join(" ")} ref={(e?: HTMLElement) => {
         e && (this._viewportElement = e);
@@ -241,16 +243,16 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     flicking.removePlugins(...removed.map(index => prevList[index]));
   }
 
-  private _hasSameChildren(prevProps: this["props"], nextProps: this["props"]) {
-    const prevChildren = this._getChildren(prevProps.children);
-    const nextChildren = this._getChildren(nextProps.children);
-
-    if (prevChildren.length !== nextChildren.length) return false;
+  private _hasSameChildren(prevChildren: React.ReactElement[], nextChildren: React.ReactElement[]) {
+    if (prevChildren.length !== nextChildren.length || prevChildren.length === 0) return false;
 
     const same = prevChildren.every((child, idx) => {
       const nextChild = nextChildren[idx];
-      if ((child as React.ReactElement).key && (nextChild as React.ReactElement).key) {
-        return (child as React.ReactElement).key === (nextChild as React.ReactElement).key;
+
+      console.log(child, nextChild);
+
+      if (child.key && nextChild.key) {
+        return child.key === nextChild.key;
       } else {
         return child === nextChild;
       }

--- a/packages/react-flicking/src/react-flicking/consts.ts
+++ b/packages/react-flicking/src/react-flicking/consts.ts
@@ -28,6 +28,7 @@ export const DEFAULT_PROPS: FlickingProps = {
   viewportTag: "div",
   cameraTag: "div",
   cameraClass: "",
+  renderOnSameKey: false,
   plugins: [],
   useFindDOMNode: false,
   hideBeforeInit: false,

--- a/packages/react-flicking/src/react-flicking/types.ts
+++ b/packages/react-flicking/src/react-flicking/types.ts
@@ -29,6 +29,7 @@ export interface FlickingProps {
   viewportTag: keyof JSX.IntrinsicElements;
   cameraTag: keyof JSX.IntrinsicElements;
   cameraClass: string;
+  renderOnSameKey: boolean;
   plugins: Plugin[];
   status?: Status;
   useFindDOMNode: boolean;


### PR DESCRIPTION
## Details
This adds a new prop `renderOnSameKey` for react-flicking, which can disable Flicking's behavior which it doesn't render when the prop `children` has the same length & keys.
