### PR TITLE
fix: fix preventClickOnDrag option working for less than 1px

### DIFF
--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -139,6 +139,7 @@ class AxesController {
     });
     this._panInput = new PanInput(flicking.viewport.element, {
       inputType: flicking.inputType,
+      threshold: 1,
       iOSEdgeSwipeThreshold: flicking.iOSEdgeSwipeThreshold,
       scale: flicking.horizontal ? [-1, 0] : [0, -1],
       releaseOnScroll: true

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -638,6 +638,36 @@ describe("Flicking", () => {
         expect(clickSpy.calledOnce).to.be.true;
       });
 
+      it("should trigger click event when Flicking's dragged under 1px", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { preventClickOnDrag: true, inputType: ["pointer"] });
+        const clickSpy = sinon.spy();
+        const testPanel = flicking.panels[0];
+
+        testPanel.element.addEventListener("click", clickSpy);
+
+        flicking.element.dispatchEvent(new PointerEvent("pointerdown", {
+          pointerId: 1,
+          buttons: 1,
+          clientX: 0,
+          clientY: 0,
+          cancelable: true,
+        }));
+
+        window.dispatchEvent(new PointerEvent("pointermove", {
+          pointerId: 1,
+          buttons: 1,
+          clientX: 0.5,
+          clientY: 0,
+          movementX: 0,
+          movementY: 0,
+          cancelable: true,
+        }));
+
+        testPanel.element.click();
+
+        expect(clickSpy.calledOnce).to.be.true;
+      });
+
       it("shouldn't trigger click event when Flicking's dragged a little", async () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { preventClickOnDrag: true });
         const clickSpy = sinon.spy();

--- a/test/unit/Flicking.spec.ts
+++ b/test/unit/Flicking.spec.ts
@@ -641,7 +641,11 @@ describe("Flicking", () => {
       it("should trigger click event when Flicking's dragged under 1px", async () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { preventClickOnDrag: true, inputType: ["pointer"] });
         const clickSpy = sinon.spy();
+        const holdStartSpy = sinon.spy();
+        const moveSpy = sinon.spy();
         const testPanel = flicking.panels[0];
+        flicking.on(EVENTS.HOLD_START, holdStartSpy);
+        flicking.on(EVENTS.MOVE, moveSpy);
 
         testPanel.element.addEventListener("click", clickSpy);
 
@@ -665,6 +669,8 @@ describe("Flicking", () => {
 
         testPanel.element.click();
 
+        expect(holdStartSpy.calledOnce).to.be.true;
+        expect(moveSpy.called).to.be.false;
         expect(clickSpy.calledOnce).to.be.true;
       });
 


### PR DESCRIPTION
## Details

According to [document](https://naver.github.io/egjs-flicking/Options#preventclickondrag), `preventClickOnDrag` option prevent `click` event if the user has dragged at least a single pixel on the viewport element.

However, some `pointermove` events have both the `movementX` and `movementY` properties of 0 and have a coordinate change less than 1 pixel.

<details>
<summary>see example `pointermove` event</summary>

```
isTrusted: true
altKey: false
altitudeAngle: 1.5707963267948966
azimuthAngle: 0
bubbles: true
button: -1
buttons: 1
cancelBubble: false
cancelable: true
clientX: 534.2734375
clientY: 60.5078125
composed: true
ctrlKey: false
currentTarget: null
defaultPrevented: true
detail: 0
eventPhase: 0
fromElement: null
height: 1
isPrimary: true
layerX: 534
layerY: 60
metaKey: false
movementX: 0
movementY: 0
offsetX: 273.2734375
offsetY: 60.5078125
pageX: 534.2734375
pageY: 60.5078125
path: (7) [div#clickable.flicking-panel.has-text-white, div.flicking-camera, div#flick.flicking-viewport, body, html, document, Window]
pointerId: 1
pointerType: "mouse"
pressure: 0.5
relatedTarget: null
returnValue: false
screenX: 534.27490234375
screenY: 597.509033203125
shiftKey: false
sourceCapabilities: null
srcElement: div#clickable.flicking-panel.has-text-white
tangentialPressure: 0
target: div#clickable.flicking-panel.has-text-white
tiltX: 0
tiltY: 0
timeStamp: 16343.40000000596
toElement: null
twist: 0
type: "pointermove"
view: Window {window: Window, self: Window, document: document, name: 'CodePen', location: Location, …}
which: 0
width: 1
x: 534.2734375
y: 60.5078125
```

</details>

You can check [this demo](https://codepen.io/malangfox/pen/WNJPWEr) that console.log is generated very infrequently when you click using the touchpad.
This demo is based on Flicking version 4.6.2 using egjs-axes v2 and hard to reproduce, this also occurs with Flicking version 4.10.0 that uses egjs-axes v3.

This issue can be fixed by setting `threshold: 1` on the PanInput. 
When this is applied, movements less than 1 pixel will no longer trigger `preventClickOnDrag` option.