### PR TITLE
docs: I updated width of post elements in css file of showcases

### DIFF
--- a/docs/src/css/showcases/post.css
+++ b/docs/src/css/showcases/post.css
@@ -60,7 +60,7 @@
   z-index: 2;
   border-left: 0;
   border-right: 0;
-  width: 88%;
+  width: 100%;
 }
 .posts .main img {
   position: absolute;


### PR DESCRIPTION
post panel main be showed with next panel element.
because .post-panel.main width: is 88% in css file

I changed this property value to 100%

.posts .flicking .post-panel.main {
  position: relative;
  z-index: 2;
  border-left: 0;
  border-right: 0;
  width: 100%;
}

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
<!-- Detailed description of the change/feature -->
