### PR TITLE
docs: update AutoPlay plugin docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.17",
     "@docusaurus/preset-classic": "^2.0.0-beta.17",
-    "@egjs/flicking-plugins": "^4.4.0",
+    "@egjs/flicking-plugins": "^4.5.0",
     "@egjs/react-flicking": "^4.10.3",
     "@egjs/react-grid": "^1.1.2",
     "@mdx-js/react": "^1.6.21",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -87,7 +87,7 @@ article a {
   margin-right: 10px;
   margin-bottom: 10px;
   align-items: flex-end;
-  justify-content: start;
+  justify-content: flex-start;
   padding-left: 20px;
   padding-right: 20px;
   padding-top: 30px;

--- a/docs/src/pages/Plugins.mdx
+++ b/docs/src/pages/Plugins.mdx
@@ -194,8 +194,10 @@ These are the available CSS files:
 |:---:|:---:|:---:|:---:|:---:|
 |options|object|✔️|{}|Options for the AutoPlay instance|
 |options.duration|number|✔️|2000|Time to wait before moving on to the next panel|
+|options.animationDuration|number \| undefined|✔️|undefined|Duration of animation of moving to the next panel. If undefined, duration option of the Flicking instance is used instead|
 |options.direction|"PREV" \| "NEXT"|✔️|"NEXT"|The direction in which the panel moves|
 |options.stopOnHover|boolean|✔️|false|Whether to stop when mouse hover upon the element|
+|options.delayAfterHover|number|✔️|options.duration|If stopOnHover is true, the amount of time to wait before moving on to the next panel when mouse leaves the element|
 
 ## Parallax
 <ParallaxDemo />

--- a/docs/src/pages/Plugins.mdx
+++ b/docs/src/pages/Plugins.mdx
@@ -194,7 +194,7 @@ These are the available CSS files:
 |:---:|:---:|:---:|:---:|:---:|
 |options|object|✔️|{}|Options for the AutoPlay instance|
 |options.duration|number|✔️|2000|Time to wait before moving on to the next panel|
-|options.animationDuration|number \| undefined|✔️|undefined|Duration of animation of moving to the next panel. If undefined, duration option of the Flicking instance is used instead|
+|options.animationDuration|number \| undefined|✔️|undefined|Duration of animation of moving to the next panel. If undefined, the duration option of the Flicking instance is used instead|
 |options.direction|"PREV" \| "NEXT"|✔️|"NEXT"|The direction in which the panel moves|
 |options.stopOnHover|boolean|✔️|false|Whether to stop when mouse hover upon the element|
 |options.delayAfterHover|number|✔️|options.duration|If stopOnHover is true, the amount of time to wait before moving on to the next panel when mouse leaves the element|


### PR DESCRIPTION
## Details
This updates documentation for [animationDuration](https://github.com/naver/egjs-flicking-plugins/pull/45) and [delayAfterHover](https://github.com/naver/egjs-flicking-plugins/pull/46) options for AutoPlay plugin.