### PR TITLE
Overlapping of Components

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -38,6 +38,9 @@ html[data-theme='dark'] {
 .navbar__brand {
   padding: var(--ifm-navbar-item-padding-vertical) 1rem;
 }
+.navbar--fixed-top {
+  z-index: 2002;
+}
 html[data-theme='dark'] .navbar__logo {
   content: url("@site/static/img/flicking_textonly_white.svg");
 }

--- a/docs/src/css/showcases/post.css
+++ b/docs/src/css/showcases/post.css
@@ -60,7 +60,7 @@
   z-index: 2;
   border-left: 0;
   border-right: 0;
-  width: 88%;
+  width: 100%;
 }
 .posts .main img {
   position: absolute;


### PR DESCRIPTION
## Issue
<!-- #765 (reference issue number for this PR) -->



## Details
<!-- Detailed description of the change/feature -->

## Description
<!-- Detailed description of the issue -->

![1](https://user-images.githubusercontent.com/48912304/206247668-b5e104eb-927f-4d50-b30c-2e38d1169bf5.PNG)
![4](https://user-images.githubusercontent.com/48912304/206247732-ac1b99c5-bfed-476f-8e60-883725c5f4ad.PNG)

I find overlapping components of Showcases Page.

![image](https://user-images.githubusercontent.com/48912304/206248084-7ef0e2a0-d097-43a0-abab-f1c843790cfe.png)

![image](https://user-images.githubusercontent.com/48912304/206248592-d26e78a3-a327-4f6b-997f-2cf6ab694fe0.png)

and checked z-index of .navbar--fixed-top and artwindow-overlay

'--ifm-z-index-fixed' value is 9 and 'z-index of artwindow-overlay' is 12 on this page

I checked this source code in local but It has different value

'--ifm-z-index-fixed' is 200 and 'z-index of artwindow-overlay' is 2001.

![image](https://user-images.githubusercontent.com/48912304/206250587-580cf074-3487-4063-a27a-be8d705d0973.png)

I tried to modify the file in the path above, but it didn't work.

I think that changed on a page that actually works.

So I added the code below to the custom.css file and modified it.

![image](https://user-images.githubusercontent.com/48912304/206251337-122ad4d4-a4fc-411f-8445-4d7601752dd8.png)

before

![bandicam-2022-12-08-01-52-40-286](https://user-images.githubusercontent.com/48912304/206252906-86ef5d15-b918-4150-8968-ed0c205cb7c7.gif)

after

![bandicam-2022-12-08-01-52-56-284](https://user-images.githubusercontent.com/48912304/206252648-bce92ba4-2ced-46d9-835e-4c864c553c90.gif)


## Steps to check or reproduce
<!-- Text description or code example (written code / JSFiddle link / etc.) -->
