### PR TITLE
fix: prevent invalid coordinate value in AxesController

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -137,6 +137,11 @@ module.exports = {
     prism: {
       theme: require("prism-react-renderer/themes/oceanicNext"),
       darkTheme: require("prism-react-renderer/themes/palenight")
+    },
+    algolia: {
+      appId: "W8GGTHANE5",
+      apiKey: "09861571e55f3970cffd575869f607d6",
+      indexName: "egjs-flicking"
     }
   },
   presets: [

--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -8,6 +8,7 @@ import Flicking from "../Flicking";
 import FlickingError from "../core/FlickingError";
 import * as AXES from "../const/axes";
 import * as ERROR from "../const/error";
+import { MOVE_TYPE } from "../const/external";
 import { circulatePosition, getFlickingAttached, parseBounce } from "../utils";
 import { ControlParams } from "../type/external";
 
@@ -378,15 +379,16 @@ class AxesController {
 
     if (duration === 0) {
       const flicking = getFlickingAttached(this._flicking);
-      const camera = flicking.camera;
 
       animate();
 
-      const newPos = flicking.circularEnabled
-        ? circulatePosition(position, camera.range.min, camera.range.max)
-        : position;
-
-      axes.axisManager.set({ [AXES.POSITION_KEY]: newPos });
+      if (flicking.moveType !== MOVE_TYPE.STRICT) {
+        const camera = flicking.camera;
+        const newPos = flicking.circularEnabled
+          ? circulatePosition(position, camera.range.min, camera.range.max)
+          : position;
+        axes.axisManager.set({ [AXES.POSITION_KEY]: newPos });
+      }
 
       return Promise.resolve();
     } else {

--- a/src/control/AxesController.ts
+++ b/src/control/AxesController.ts
@@ -8,8 +8,7 @@ import Flicking from "../Flicking";
 import FlickingError from "../core/FlickingError";
 import * as AXES from "../const/axes";
 import * as ERROR from "../const/error";
-import { MOVE_TYPE } from "../const/external";
-import { circulatePosition, getFlickingAttached, parseBounce } from "../utils";
+import { getFlickingAttached, parseBounce } from "../utils";
 import { ControlParams } from "../type/external";
 
 import StateMachine from "./StateMachine";
@@ -377,38 +376,22 @@ class AxesController {
       }
     };
 
-    if (duration === 0) {
-      const flicking = getFlickingAttached(this._flicking);
+    return new Promise((resolve, reject) => {
+      const animationFinishHandler = () => {
+        axes.off(AXES.EVENT.HOLD, interruptionHandler);
+        resolve();
+      };
+
+      const interruptionHandler = () => {
+        axes.off(AXES.EVENT.FINISH, animationFinishHandler);
+        reject(new FlickingError(ERROR.MESSAGE.ANIMATION_INTERRUPTED, ERROR.CODE.ANIMATION_INTERRUPTED));
+      };
+
+      axes.once(AXES.EVENT.FINISH, animationFinishHandler);
+      axes.once(AXES.EVENT.HOLD, interruptionHandler);
 
       animate();
-
-      if (flicking.moveType !== MOVE_TYPE.STRICT) {
-        const camera = flicking.camera;
-        const newPos = flicking.circularEnabled
-          ? circulatePosition(position, camera.range.min, camera.range.max)
-          : position;
-        axes.axisManager.set({ [AXES.POSITION_KEY]: newPos });
-      }
-
-      return Promise.resolve();
-    } else {
-      return new Promise((resolve, reject) => {
-        const animationFinishHandler = () => {
-          axes.off(AXES.EVENT.HOLD, interruptionHandler);
-          resolve();
-        };
-
-        const interruptionHandler = () => {
-          axes.off(AXES.EVENT.FINISH, animationFinishHandler);
-          reject(new FlickingError(ERROR.MESSAGE.ANIMATION_INTERRUPTED, ERROR.CODE.ANIMATION_INTERRUPTED));
-        };
-
-        axes.once(AXES.EVENT.FINISH, animationFinishHandler);
-        axes.once(AXES.EVENT.HOLD, interruptionHandler);
-
-        animate();
-      });
-    }
+    });
   }
 
   public updateDirection() {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -214,7 +214,7 @@ export const circulatePosition = (pos: number, min: number, max: number) => {
   if (pos < min) {
     const offset = (min - pos) % size;
     pos = max - offset;
-  } else if (pos > max) {
+  } else if (pos >= max) {
     const offset = (pos - max) % size;
     pos = min + offset;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -214,7 +214,7 @@ export const circulatePosition = (pos: number, min: number, max: number) => {
   if (pos < min) {
     const offset = (min - pos) % size;
     pos = max - offset;
-  } else if (pos >= max) {
+  } else if (pos > max) {
     const offset = (pos - max) % size;
     pos = min + offset;
   }

--- a/test/unit/control/AxesController.spec.ts
+++ b/test/unit/control/AxesController.spec.ts
@@ -123,10 +123,11 @@ describe("AxesController", () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
         controller.init(flicking);
 
-        // No tick() is involved, so passing this test means that promise is resolved immediately
-        await controller.animateTo(1000, 0);
-
-        expect(controller.position).to.equal(1000);
+        flicking.once("ready", async () => {
+          await controller.animateTo(1000, 0);
+          // No tick() is involved, so passing this test means that promise is resolved immediately
+          expect(controller.position).to.equal(1000);
+        });
       });
 
       it("should be resolved immediately if given position is same to current position", async () => {

--- a/test/unit/control/AxesController.spec.ts
+++ b/test/unit/control/AxesController.spec.ts
@@ -93,9 +93,8 @@ describe("AxesController", () => {
       });
 
       it("should call `setTo` of the axes instance", async () => {
-        const controller = new AxesController();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
-        controller.init(flicking);
+        const controller = flicking.control.controller;
         const setToSpy = sinon.spy(controller.axes, "setTo");
 
         void controller.animateTo(1000, 1000);
@@ -106,9 +105,8 @@ describe("AxesController", () => {
       });
 
       it("should call `setTo` of the axes onRelease event if given", async () => {
-        const controller = new AxesController();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
-        controller.init(flicking);
+        const controller = flicking.control.controller;
         const onReleaseMock = { setTo: sinon.spy() };
 
         void controller.animateTo(1000, 1000, onReleaseMock as any);
@@ -119,21 +117,17 @@ describe("AxesController", () => {
       });
 
       it("should be resolved immediately if duration is 0", async () => {
-        const controller = new AxesController();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
-        controller.init(flicking);
+        const controller = flicking.control.controller;
 
-        flicking.once("ready", async () => {
-          await controller.animateTo(1000, 0);
-          // No tick() is involved, so passing this test means that promise is resolved immediately
-          expect(controller.position).to.equal(1000);
-        });
+        await controller.animateTo(1000, 0);
+        // No tick() is involved, so passing this test means that promise is resolved immediately
+        expect(controller.position).to.equal(1000);
       });
 
       it("should be resolved immediately if given position is same to current position", async () => {
-        const controller = new AxesController();
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
-        controller.init(flicking);
+        const controller = flicking.control.controller;
 
         const prevPos = controller.position;
 


### PR DESCRIPTION
## Details
When using a specific combination of options such as below, the internal position exceeds the range of coordinates.
```
{
  circular: true,
  align: "prev",
  duration: 0,
  moveType: "strict"
}
```
Here is the [reproduction demo](https://codepen.io/malangfox/pen/QWByPgp) of this issue.
When you click the panel, the internal coordinates and range change as shown below at the last point,

![image](https://user-images.githubusercontent.com/13797320/209890310-e1facf10-0cf8-4d34-8e6c-138129104b29.png)

And when you interact with Flicking once more, it shows an abnormal movement to return this value to 0 in the range.

This was because the `animateTo` in AxesController updates the range and position one more time separately from the strict control update range and position when duration is 0.


According to what I have checked, only the strict type has the behavior of changing the pos and range of the Axes instance when the panel is changed.
```ts
  public setActive = (newActivePanel: Panel, prevActivePanel: Panel | null, isTrusted: boolean) => {
    super.setActive(newActivePanel, prevActivePanel, isTrusted);
    this.updateInput();
  };
```
So, I removed unnecessary behavior of `animateTo` in strict move type.