### PR TITLE
fix: control fallback when interrupted

### DIFF
--- a/src/control/SnapControl.ts
+++ b/src/control/SnapControl.ts
@@ -113,8 +113,8 @@ class SnapControl extends Control {
       // Move to the adjacent panel
       targetAnchor = this._findAdjacentAnchor(position, posDelta, anchorAtCamera);
     } else {
-      // Restore to active panel
-      return this.moveToPanel(activeAnchor.panel, {
+      // Fallback to nearest panel from current camera
+      return this.moveToPanel(anchorAtCamera.panel, {
         duration,
         axesEvent
       });

--- a/src/control/StrictControl.ts
+++ b/src/control/StrictControl.ts
@@ -242,8 +242,8 @@ class StrictControl extends Control {
       targetPanel = adjacentAnchor!.panel;
       targetPos = adjacentAnchor!.position;
     } else {
-      // Restore to active panel
-      targetPos = camera.clampToReachablePosition(activePanel.position);
+      // Fallback to nearest panel from current camera
+      targetPos = camera.clampToReachablePosition(anchorAtPosition.position);
       targetPanel = activePanel;
     }
 

--- a/src/control/StrictControl.ts
+++ b/src/control/StrictControl.ts
@@ -243,8 +243,14 @@ class StrictControl extends Control {
       targetPos = adjacentAnchor!.position;
     } else {
       // Fallback to nearest panel from current camera
-      targetPos = camera.clampToReachablePosition(anchorAtPosition.position);
-      targetPanel = activePanel;
+      const anchorAtCamera = camera.findNearestAnchor(camera.position);
+      if (!anchorAtCamera) {
+        return Promise.reject(new FlickingError(ERROR.MESSAGE.POSITION_NOT_REACHABLE(position), ERROR.CODE.POSITION_NOT_REACHABLE));
+      }
+      return this.moveToPanel(anchorAtCamera.panel, {
+        duration,
+        axesEvent
+      });
     }
 
     this._triggerIndexChangeEvent(targetPanel, position, axesEvent);

--- a/test/unit/control/SnapControl.spec.ts
+++ b/test/unit/control/SnapControl.spec.ts
@@ -291,6 +291,7 @@ describe("SnapControl", () => {
 
         const control = flicking.control;
         const camera = flicking.camera;
+        const moveSpy = sinon.spy(control, "moveToPanel");
 
         // Suppress animation interrupt error
         const promise = flicking.moveTo(2, 1500).catch(error => error);
@@ -301,6 +302,7 @@ describe("SnapControl", () => {
         tick(1000);
         await promise;
 
+        expect(moveSpy.calledTwice).to.be.true;
         expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
       });
     });

--- a/test/unit/control/SnapControl.spec.ts
+++ b/test/unit/control/SnapControl.spec.ts
@@ -282,6 +282,27 @@ describe("SnapControl", () => {
         expect(position).to.be.lessThan(flicking.panels[flicking.panelCount - 1].position);
         expect(position).to.equal(flicking.panels[0].position);
       });
+
+      it("Should move to the nearest panel from the camera, when animation is interrupted by user input", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, {
+          moveType: MOVE_TYPE.SNAP,
+          align: "prev",
+        });
+
+        const control = flicking.control;
+        const camera = flicking.camera;
+
+        // Suppress animation interrupt error
+        const promise = flicking.moveTo(2, 1500).catch(error => error);
+        tick(500);
+        const position = camera.position;
+        // Simulate interrupt
+        await simulate(flicking.element, { deltaX: 0, duration: 100 }, 1000);
+        tick(1000);
+        await promise;
+
+        expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
+      });
     });
   });
 });

--- a/test/unit/control/StrictControl.spec.ts
+++ b/test/unit/control/StrictControl.spec.ts
@@ -4,7 +4,7 @@ import * as ERROR from "~/const/error";
 import { MOVE_TYPE } from "~/const/external";
 
 import El from "../helper/El";
-import { createFlicking, simulate } from "../helper/test-util";
+import { createFlicking, simulate, tick } from "../helper/test-util";
 
 describe("StrictControl", () => {
   describe("Methods", () => {
@@ -265,6 +265,24 @@ describe("StrictControl", () => {
         await control.moveToPosition(99999999, 0);
 
         expect(flicking.index).to.equal(lastAnchor.panel.index);
+      });
+
+      it("Should move to the nearest panel from the camera, when animation is interrupted by user input", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { moveType: MOVE_TYPE.STRICT });
+
+        const control = flicking.control;
+        const camera = flicking.camera;
+
+        // Suppress animation interrupt error
+        const promise = flicking.moveTo(1, 1500).catch(error => error);
+        tick(100);
+        const position = camera.position;
+        // Simulate interrupt
+        await simulate(flicking.element, { deltaX: 0, duration: 100 }, 1000);
+        tick(1000);
+        await promise;
+
+        expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
       });
     });
   });

--- a/test/unit/control/StrictControl.spec.ts
+++ b/test/unit/control/StrictControl.spec.ts
@@ -272,6 +272,7 @@ describe("StrictControl", () => {
 
         const control = flicking.control;
         const camera = flicking.camera;
+        const moveSpy = sinon.spy(control, "moveToPanel");
 
         // Suppress animation interrupt error
         const promise = flicking.moveTo(1, 1500).catch(error => error);
@@ -282,6 +283,7 @@ describe("StrictControl", () => {
         tick(1000);
         await promise;
 
+        expect(moveSpy.calledTwice).to.be.true;
         expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
       });
     });


### PR DESCRIPTION
## Issue
#776

## Details
When control is set to SnapControl or StrictControl, click event during panel sliding triggers restore behavior.
``` js
// src/control/SnapControl.ts > SnapControl > moveToPosition

// Restore to active panel
return this.moveToPanel(activeAnchor.panel, {
  duration,
  axesEvent
});
```
To reproduce, go to [official demo](https://naver.github.io/egjs-flicking/ko/Demos), drag fast, then click during sliding. When mouseup, the panel restores to starting position.

However this behavior in most circumstances are rather confusing to end user since the camera has already moved far from original panel but it restores to original position.
So it would feel more natural for camera to slide to nearest panel when interrupted.
``` js
// src/control/SnapControl.ts > SnapControl > moveToPosition

// Fallback to nearest panel from current camera
return this.moveToPanel(anchorAtCamera.panel, {
  duration,
  axesEvent
});
```
## Caveats
It passed the unit test but I'm not sure if changing restore behavior will cause other side effects rather than click interrupt during sliding.
