### PR TITLE
fix: misspelled event name on removeEventListener

### DIFF
--- a/src/core/ResizeWatcher.ts
+++ b/src/core/ResizeWatcher.ts
@@ -67,7 +67,7 @@ class ResizeWatcher {
   public destroy() {
     this._observer?.disconnect();
     if (this._options.useWindowResize) {
-      window.removeEventListener("reisze", this._onResize);
+      window.removeEventListener("resize", this._onResize);
     }
   }
 


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
Fix misspelled event name "resize" on removeEventListener
