### PR TITLE
fix: apply transform after elements are fully rendered

### DIFF
--- a/packages/ngx-flicking/projects/ngx-flicking/src/lib/NgxRenderer.ts
+++ b/packages/ngx-flicking/projects/ngx-flicking/src/lib/NgxRenderer.ts
@@ -36,7 +36,7 @@ class NgxRenderer extends ExternalRenderer {
     strategy.renderPanels(flicking);
 
     this._resetPanelElementOrder();
-    flicking.camera.applyTransform();
+    this._afterRender();
   }
 
   protected _collectPanels() {

--- a/packages/ngx-flicking/projects/ngx-flicking/src/lib/NgxRenderer.ts
+++ b/packages/ngx-flicking/projects/ngx-flicking/src/lib/NgxRenderer.ts
@@ -36,6 +36,7 @@ class NgxRenderer extends ExternalRenderer {
     strategy.renderPanels(flicking);
 
     this._resetPanelElementOrder();
+    flicking.camera.applyTransform();
   }
 
   protected _collectPanels() {

--- a/packages/react-flicking/src/react-flicking/ReactRenderer.ts
+++ b/packages/react-flicking/src/react-flicking/ReactRenderer.ts
@@ -36,7 +36,8 @@ class ReactRenderer extends ExternalRenderer {
     return new Promise<void>(resolve => {
       reactFlicking.renderEmitter.once("render", () => {
         this._rendering = false;
-        resolve()
+        flicking.camera.applyTransform();
+        resolve();
       });
       reactFlicking.forceUpdate();
     });

--- a/packages/react-flicking/src/react-flicking/ReactRenderer.ts
+++ b/packages/react-flicking/src/react-flicking/ReactRenderer.ts
@@ -36,7 +36,7 @@ class ReactRenderer extends ExternalRenderer {
     return new Promise<void>(resolve => {
       reactFlicking.renderEmitter.once("render", () => {
         this._rendering = false;
-        flicking.camera.applyTransform();
+        this._afterRender();
         resolve();
       });
       reactFlicking.forceUpdate();

--- a/packages/svelte-flicking/src/SvelteRenderer.ts
+++ b/packages/svelte-flicking/src/SvelteRenderer.ts
@@ -36,7 +36,7 @@ class SvelteRenderer extends ExternalRenderer {
 
     return new Promise<void>(resolve => {
       this._renderEmitter.once("render", () => {
-        flicking.camera.applyTransform();
+        this._afterRender();
         resolve();
       });
       this._applyPanelOrder();

--- a/packages/svelte-flicking/src/SvelteRenderer.ts
+++ b/packages/svelte-flicking/src/SvelteRenderer.ts
@@ -35,7 +35,10 @@ class SvelteRenderer extends ExternalRenderer {
     strategy.renderPanels(flicking);
 
     return new Promise<void>(resolve => {
-      this._renderEmitter.once("render", resolve);
+      this._renderEmitter.once("render", () => {
+        flicking.camera.applyTransform();
+        resolve();
+      });
       this._applyPanelOrder();
       this._forceUpdate();
     });

--- a/packages/vue-flicking/src/VueRenderer.ts
+++ b/packages/vue-flicking/src/VueRenderer.ts
@@ -36,7 +36,7 @@ class VueRenderer extends ExternalRenderer {
 
     return new Promise<void>((resolve) => {
       vueFlicking.$once("render", () => {
-        flicking.camera.applyTransform();
+        this._afterRender();
         resolve();
       });
       vueFlicking.$forceUpdate();

--- a/packages/vue-flicking/src/VueRenderer.ts
+++ b/packages/vue-flicking/src/VueRenderer.ts
@@ -35,7 +35,10 @@ class VueRenderer extends ExternalRenderer {
     strategy.renderPanels(flicking);
 
     return new Promise<void>((resolve) => {
-      vueFlicking.$once("render", resolve);
+      vueFlicking.$once("render", () => {
+        flicking.camera.applyTransform();
+        resolve();
+      });
       vueFlicking.$forceUpdate();
     });
   }

--- a/packages/vue3-flicking/src/VueRenderer.ts
+++ b/packages/vue3-flicking/src/VueRenderer.ts
@@ -36,7 +36,7 @@ class VueRenderer extends ExternalRenderer {
 
     return new Promise<void>((resolve) => {
       vueFlicking.renderEmitter.once("render", () => {
-        flicking.camera.applyTransform();
+        this._afterRender();
         resolve();
       });
       vueFlicking.$forceUpdate();

--- a/packages/vue3-flicking/src/VueRenderer.ts
+++ b/packages/vue3-flicking/src/VueRenderer.ts
@@ -35,7 +35,10 @@ class VueRenderer extends ExternalRenderer {
     strategy.renderPanels(flicking);
 
     return new Promise<void>((resolve) => {
-      vueFlicking.renderEmitter.once("render", resolve);
+      vueFlicking.renderEmitter.once("render", () => {
+        flicking.camera.applyTransform();
+        resolve();
+      });
       vueFlicking.$forceUpdate();
     });
   }

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1070,7 +1070,7 @@ class Flicking extends Component<FlickingEvents> {
     return renderer.render().then(() => {
       // Done initializing & emit ready event
       this._plugins.forEach(plugin => plugin.init(this));
-      camera.applyTransform();
+
       if (preventEventsBeforeInit) {
         this.trigger = originalTrigger;
       }

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1065,11 +1065,12 @@ class Flicking extends Component<FlickingEvents> {
       this.disableInput();
     }
     renderer.checkPanelContentsReady(renderer.panels);
+    this._initialized = true;
 
     return renderer.render().then(() => {
       // Done initializing & emit ready event
       this._plugins.forEach(plugin => plugin.init(this));
-      this._initialized = true;
+      camera.applyTransform();
       if (preventEventsBeforeInit) {
         this.trigger = originalTrigger;
       }

--- a/src/camera/Camera.ts
+++ b/src/camera/Camera.ts
@@ -551,7 +551,7 @@ class Camera {
     const flicking = getFlickingAttached(this._flicking);
     const renderer = flicking.renderer;
 
-    if (renderer.rendering) return this;
+    if (renderer.rendering || !flicking.initialized) return this;
 
     const actualPosition = this._position - this._alignPos - this._offset + this._circularOffset;
 

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -536,6 +536,12 @@ abstract class Renderer {
       cameraElement.removeChild(panel.element);
     });
   }
+
+  protected _afterRender() {
+    const flicking = getFlickingAttached(this._flicking);
+
+    flicking.camera.applyTransform();
+  }
 }
 
 export default Renderer;

--- a/src/renderer/VanillaRenderer.ts
+++ b/src/renderer/VanillaRenderer.ts
@@ -20,7 +20,7 @@ class VanillaRenderer extends Renderer {
     strategy.renderPanels(flicking);
 
     this._resetPanelElementOrder();
-    flicking.camera.applyTransform();
+    this._afterRender();
   }
 
   protected _collectPanels() {

--- a/src/renderer/VanillaRenderer.ts
+++ b/src/renderer/VanillaRenderer.ts
@@ -20,6 +20,7 @@ class VanillaRenderer extends Renderer {
     strategy.renderPanels(flicking);
 
     this._resetPanelElementOrder();
+    flicking.camera.applyTransform();
   }
 
   protected _collectPanels() {

--- a/test/manual/js/index.js
+++ b/test/manual/js/index.js
@@ -1,4 +1,5 @@
 const flicking = new Flicking("#flicking", {
   circular: true,
+  defaultIndex: 1,
   align: "prev"
 });


### PR DESCRIPTION
## Issue
#773 

## Details
This fixes #773 by delaying CSS transform application until the elements are fully rendered in the correct order.
This can fix panels flickering on the first render in the SSR frameworks.