### PR TITLE
fix: off render event handling when destroy occurs

### DIFF
--- a/packages/react-flicking/src/index.tsx
+++ b/packages/react-flicking/src/index.tsx
@@ -1,12 +1,16 @@
-import React from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./demo/App";
 import * as serviceWorker from "./demo/serviceWorker";
 
 const container = document.getElementById("root");
-const root = createRoot(container);
+const root = createRoot(container as HTMLElement);
 
-root.render(<App />);
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/packages/react-flicking/src/react-flicking/ReactRenderer.ts
+++ b/packages/react-flicking/src/react-flicking/ReactRenderer.ts
@@ -58,6 +58,11 @@ class ReactRenderer extends ExternalRenderer {
     });
   }
 
+  public destroy() {
+    super.destroy();
+    this._reactFlicking.renderEmitter.off("render");
+  }
+
   protected _collectPanels() {
     const flicking = getFlickingAttached(this._flicking);
     const reactFlicking = this._reactFlicking;

--- a/src/renderer/Renderer.ts
+++ b/src/renderer/Renderer.ts
@@ -538,9 +538,11 @@ abstract class Renderer {
   }
 
   protected _afterRender() {
-    const flicking = getFlickingAttached(this._flicking);
+    if (this._flicking) {
+      const flicking = getFlickingAttached(this._flicking);
 
-    flicking.camera.applyTransform();
+      flicking.camera.applyTransform();
+    }
   }
 }
 


### PR DESCRIPTION
## Issue
This fix resolves #785 
This issue seems to be happening in strict mode in react, and I am considering whether we should provide this fix for every framework environment for the possibility of a similar issue may be happening.

If so, I'll fix the vue and svelte parts too.