### PR TITLE
docs: fix misspelled path in document

### DIFF
--- a/docs/docs/tutorials/quick-start.mdx
+++ b/docs/docs/tutorials/quick-start.mdx
@@ -223,9 +223,9 @@ export default {
 }
 ```
 ```css title="SomeComponent.vue - <style>"
-@import url("node_modules/@egjs/vue-flicking/dist/flicking.css");
+@import url("node_modules/@egjs/vue3-flicking/dist/flicking.css");
 // Or, if you have to support IE9
-@import url("node_modules/@egjs/vue-flicking/dist/flicking-inline.css");
+@import url("node_modules/@egjs/vue3-flicking/dist/flicking-inline.css");
 ```
 
 or globally.


### PR DESCRIPTION
## Issue
#793 

## Details
This fixes misspelled css path in quick start document.