### PR TITLE
fix: fix setStatus not working when index is 0

### DIFF
--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1397,7 +1397,7 @@ class Flicking extends Component<FlickingEvents> {
       renderer.batchInsert({ index: 0, elements: parseElement(panels.map(panel => panel.html!)), hasDOMInElements: true });
     }
 
-    if (index !== undefined) {
+    if (index != null) {
       const panelIndex = visibleOffset
         ? index - visibleOffset
         : index;

--- a/src/Flicking.ts
+++ b/src/Flicking.ts
@@ -1397,7 +1397,7 @@ class Flicking extends Component<FlickingEvents> {
       renderer.batchInsert({ index: 0, elements: parseElement(panels.map(panel => panel.html!)), hasDOMInElements: true });
     }
 
-    if (index) {
+    if (index !== undefined) {
       const panelIndex = visibleOffset
         ? index - visibleOffset
         : index;


### PR DESCRIPTION
## Issue
#795 
A [demo](https://codepen.io/malangfox/pen/QWVebpj) that reproduces the issue.

## Details
This is a bug caused by `if (index)` is false when index is 0.


