### PR TITLE
docs(egjs-flicking): tutorial doc contains link that 404s

### DIFF
--- a/docs/docs/tutorials/listening-to-events.mdx
+++ b/docs/docs/tutorials/listening-to-events.mdx
@@ -25,7 +25,7 @@ import TabItem from '@theme/TabItem';
   ]}>
   <TabItem value="js">
 
-You can listen to Flicking's events with [Flicking#on](useBaseUrl(api/Flicking#on))
+You can listen to Flicking's events with <Link to={useBaseUrl("docs/api/Flicking#on")}>Flicking#on</Link>
 
 ```js
 // If you're using a package manager

--- a/docs/docs/tutorials/listening-to-events.mdx
+++ b/docs/docs/tutorials/listening-to-events.mdx
@@ -25,7 +25,7 @@ import TabItem from '@theme/TabItem';
   ]}>
   <TabItem value="js">
 
-You can listen to Flicking's events with [Flicking#on](api/Flicking#on)
+You can listen to Flicking's events with [Flicking#on](useBaseUrl(api/Flicking#on))
 
 ```js
 // If you're using a package manager


### PR DESCRIPTION
Ref #798

## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->
798

## Details
<!-- Detailed description of the change/feature -->
- before
```
# egjs-flicking/docs/docs/tutorials/listening-to-events.mdx, 28th lines
You can listen to Flicking's events with [Flicking#on](api/Flicking#on)
```

- after
```
# egjs-flicking/docs/docs/tutorials/listening-to-events.mdx, 28th lines
You can listen to Flicking's events with [Flicking#on](useBaseUrl(api/Flicking#on))
```
