### PR TITLE
docs: add info for circular option in related demo

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/Flicking.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/api/Flicking.mdx
@@ -12,7 +12,7 @@ class Flicking extends Component
 
 <div className="container">
   <div className="row mb-2"><div className="col col--4"><strong>Properties</strong></div><div className="col col--4"><strong>Methods</strong></div><div className="col col--4"><strong>Events</strong></div></div>
-  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
+  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a><br/><a href="#trigger">trigger</a><br/><a href="#once">once</a><br/><a href="#hasOn">hasOn</a><br/><a href="#on">on</a><br/><a href="#off">off</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
 </div>
 
 ## constructor
@@ -1204,6 +1204,183 @@ flicking.insert(3, "\<div\>Panel 1\</div\>\<div\>Panel 2\</div\>");
 |:---:|:---:|:---:|:---:|:---:|
 |index|number|||제거할 패널의 인덱스|
 |deleteCount|number|✔️|1|`index` 이후로 제거할 패널의 개수|
+
+### trigger {#trigger}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+커스텀 이벤트를 발생시킨다
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|event|string \| ComponentEvent|||발생할 커스텀 이벤트의 이름 또는 ComponentEvent의 인스턴스|
+|params|Array&lt;any&gt; \| $ts:...|||커스텀 이벤트가 발생할 때 전달할 데이터|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  beforeHi: ComponentEvent<{ foo: number; bar: string }>;
+  hi: { foo: { a: number; b: boolean } };
+  someEvent: (foo: number, bar: string) => void;
+  someOtherEvent: void; // When there's no event argument
+}> {
+  some(){
+    if(this.trigger("beforeHi")){ // When event call to stop return false.
+      this.trigger("hi");// fire hi event.
+    }
+  }
+}
+
+const some = new Some();
+some.on("beforeHi", e => {
+  if(condition){
+    e.stop(); // When event call to stop, `hi` event not call.
+  }
+  // `currentTarget` is component instance.
+  console.log(some === e.currentTarget); // true
+
+  typeof e.foo; // number
+  typeof e.bar; // string
+});
+some.on("hi", e => {
+  typeof e.foo.b; // boolean
+});
+// If you want to more know event design. You can see article.
+// https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
+```
+
+### once {#once}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+이벤트가 한번만 실행된다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||등록할 이벤트의 이름 또는 이벤트 이름-핸들러 오브젝트|
+|handlerToAttach|function \| $ts:...|✔️||등록할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: ComponentEvent;
+}> {
+  hi() {
+    alert("hi");
+  }
+  thing() {
+    this.once("hi", this.hi);
+  }
+}
+
+var some = new Some();
+some.thing();
+some.trigger(new ComponentEvent("hi"));
+// fire alert("hi");
+some.trigger(new ComponentEvent("hi"));
+// Nothing happens
+```
+
+### hasOn {#hasOn}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 이벤트가 등록됐는지 확인한다.
+
+**Returns**: boolean
+- 이벤트 등록 여부
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string|||등록 여부를 확인할 이벤트의 이름|
+
+```ts
+import Component from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  some() {
+    this.hasOn("hi");// check hi event.
+  }
+}
+```
+
+### on {#on}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 이벤트를 등록한다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||등록할 이벤트의 이름 또는 이벤트 이름-핸들러 오브젝트|
+|handlerToAttach|function \| $ts:...|✔️||등록할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.on("hi",this.hi); //attach event
+  }
+}
+```
+
+### off {#off}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 등록된 이벤트를 해제한다.<br/>`eventName`이 주어지지 않았을 경우 모든 이벤트 핸들러를 제거한다.<br/>`handlerToAttach`가 주어지지 않았을 경우 `eventName`에 해당하는 모든 이벤트 핸들러를 제거한다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|✔️||해제할 이벤트의 이름|
+|handlerToDetach|function \| $ts:...|✔️||해제할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.off("hi",this.hi); //detach event
+  }
+}
+```
 
 ## Events
 ### ready {#event-ready}

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.10.7/api/Flicking.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.10.7/api/Flicking.mdx
@@ -12,7 +12,7 @@ class Flicking extends Component
 
 <div className="container">
   <div className="row mb-2"><div className="col col--4"><strong>Properties</strong></div><div className="col col--4"><strong>Methods</strong></div><div className="col col--4"><strong>Events</strong></div></div>
-  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
+  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a><br/><a href="#trigger">trigger</a><br/><a href="#once">once</a><br/><a href="#hasOn">hasOn</a><br/><a href="#on">on</a><br/><a href="#off">off</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
 </div>
 
 ## constructor
@@ -1204,6 +1204,183 @@ flicking.insert(3, "\<div\>Panel 1\</div\>\<div\>Panel 2\</div\>");
 |:---:|:---:|:---:|:---:|:---:|
 |index|number|||제거할 패널의 인덱스|
 |deleteCount|number|✔️|1|`index` 이후로 제거할 패널의 개수|
+
+### trigger {#trigger}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+커스텀 이벤트를 발생시킨다
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|event|string \| ComponentEvent|||발생할 커스텀 이벤트의 이름 또는 ComponentEvent의 인스턴스|
+|params|Array&lt;any&gt; \| $ts:...|||커스텀 이벤트가 발생할 때 전달할 데이터|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  beforeHi: ComponentEvent<{ foo: number; bar: string }>;
+  hi: { foo: { a: number; b: boolean } };
+  someEvent: (foo: number, bar: string) => void;
+  someOtherEvent: void; // When there's no event argument
+}> {
+  some(){
+    if(this.trigger("beforeHi")){ // When event call to stop return false.
+      this.trigger("hi");// fire hi event.
+    }
+  }
+}
+
+const some = new Some();
+some.on("beforeHi", e => {
+  if(condition){
+    e.stop(); // When event call to stop, `hi` event not call.
+  }
+  // `currentTarget` is component instance.
+  console.log(some === e.currentTarget); // true
+
+  typeof e.foo; // number
+  typeof e.bar; // string
+});
+some.on("hi", e => {
+  typeof e.foo.b; // boolean
+});
+// If you want to more know event design. You can see article.
+// https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
+```
+
+### once {#once}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+이벤트가 한번만 실행된다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||등록할 이벤트의 이름 또는 이벤트 이름-핸들러 오브젝트|
+|handlerToAttach|function \| $ts:...|✔️||등록할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: ComponentEvent;
+}> {
+  hi() {
+    alert("hi");
+  }
+  thing() {
+    this.once("hi", this.hi);
+  }
+}
+
+var some = new Some();
+some.thing();
+some.trigger(new ComponentEvent("hi"));
+// fire alert("hi");
+some.trigger(new ComponentEvent("hi"));
+// Nothing happens
+```
+
+### hasOn {#hasOn}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 이벤트가 등록됐는지 확인한다.
+
+**Returns**: boolean
+- 이벤트 등록 여부
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string|||등록 여부를 확인할 이벤트의 이름|
+
+```ts
+import Component from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  some() {
+    this.hasOn("hi");// check hi event.
+  }
+}
+```
+
+### on {#on}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 이벤트를 등록한다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||등록할 이벤트의 이름 또는 이벤트 이름-핸들러 오브젝트|
+|handlerToAttach|function \| $ts:...|✔️||등록할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.on("hi",this.hi); //attach event
+  }
+}
+```
+
+### off {#off}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+컴포넌트에 등록된 이벤트를 해제한다.<br/>`eventName`이 주어지지 않았을 경우 모든 이벤트 핸들러를 제거한다.<br/>`handlerToAttach`가 주어지지 않았을 경우 `eventName`에 해당하는 모든 이벤트 핸들러를 제거한다.
+
+**Returns**: this
+- 컴포넌트 자신의 인스턴스
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|✔️||해제할 이벤트의 이름|
+|handlerToDetach|function \| $ts:...|✔️||해제할 이벤트의 핸들러 함수|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.off("hi",this.hi); //detach event
+  }
+}
+```
 
 ## Events
 ### ready {#event-ready}

--- a/docs/src/pages/Demos.mdx
+++ b/docs/src/pages/Demos.mdx
@@ -12,6 +12,8 @@ import WeatherDisplay from "@site/src/demo/WeatherDisplay";
 import DateSelector from "@site/src/demo/DateSelector";
 import LazyLoad from "@site/src/demo/LazyLoad";
 import Nested from "@site/src/demo/Nested";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 # Demos
 ## Panel add / remove
@@ -22,6 +24,9 @@ import Nested from "@site/src/demo/Nested";
 
 ## Variable Size Panels
 Flicking uses panel element's real size, and doesn't modify them.
+:::info
+Check out the <Link to={useBaseUrl("Options#circular")}>circular</Link> option, which provides a continuous loop depending on the Panel's size
+:::
 <Flicking className="my-4" circular={true}>
   <Panel color="primary" style={{ width: "120px" }} index={0} />
   <Panel color="danger" style={{ width: "20%" }} index={1} />

--- a/docs/versioned_docs/version-4.10.7/api/Flicking.mdx
+++ b/docs/versioned_docs/version-4.10.7/api/Flicking.mdx
@@ -12,7 +12,7 @@ class Flicking extends Component
 
 <div className="container">
   <div className="row mb-2"><div className="col col--4"><strong>Properties</strong></div><div className="col col--4"><strong>Methods</strong></div><div className="col col--4"><strong>Events</strong></div></div>
-  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
+  <div className="row"><div className="col col--4"><a href="#VERSION">VERSION</a><span className="badge badge--info margin-left--sm">static</span><br/><a href="#control">control</a><br/><a href="#camera">camera</a><br/><a href="#renderer">renderer</a><br/><a href="#viewport">viewport</a><br/><a href="#initialized">initialized</a><br/><a href="#circularEnabled">circularEnabled</a><br/><a href="#virtualEnabled">virtualEnabled</a><br/><a href="#index">index</a><br/><a href="#element">element</a><br/><a href="#currentPanel">currentPanel</a><br/><a href="#panels">panels</a><br/><a href="#panelCount">panelCount</a><br/><a href="#visiblePanels">visiblePanels</a><br/><a href="#animating">animating</a><br/><a href="#holding">holding</a><br/><a href="#activePlugins">activePlugins</a><br/><a href="#align">align</a><br/><a href="#defaultIndex">defaultIndex</a><br/><a href="#horizontal">horizontal</a><br/><a href="#circular">circular</a><br/><a href="#circularFallback">circularFallback</a><br/><a href="#bound">bound</a><br/><a href="#adaptive">adaptive</a><br/><a href="#panelsPerView">panelsPerView</a><br/><a href="#noPanelStyleOverride">noPanelStyleOverride</a><br/><a href="#resizeOnContentsReady">resizeOnContentsReady</a><br/><a href="#nested">nested</a><br/><a href="#needPanelThreshold">needPanelThreshold</a><br/><a href="#preventEventsBeforeInit">preventEventsBeforeInit</a><br/><a href="#deceleration">deceleration</a><br/><a href="#easing">easing</a><br/><a href="#duration">duration</a><br/><a href="#inputType">inputType</a><br/><a href="#moveType">moveType</a><br/><a href="#threshold">threshold</a><br/><a href="#interruptable">interruptable</a><br/><a href="#bounce">bounce</a><br/><a href="#iOSEdgeSwipeThreshold">iOSEdgeSwipeThreshold</a><br/><a href="#preventClickOnDrag">preventClickOnDrag</a><br/><a href="#disableOnInit">disableOnInit</a><br/><a href="#changeOnHold">changeOnHold</a><br/><a href="#renderOnlyVisible">renderOnlyVisible</a><br/><a href="#virtual">virtual</a><br/><a href="#autoInit">autoInit</a><br/><a href="#autoResize">autoResize</a><br/><a href="#useResizeObserver">useResizeObserver</a><br/><a href="#resizeDebounce">resizeDebounce</a><br/><a href="#maxResizeDebounce">maxResizeDebounce</a><br/><a href="#useFractionalSize">useFractionalSize</a><br/><a href="#externalRenderer">externalRenderer</a><br/><a href="#renderExternal">renderExternal</a></div><div className="col col--4"><a href="#init">init</a><br/><a href="#destroy">destroy</a><br/><a href="#prev">prev</a><br/><a href="#next">next</a><br/><a href="#moveTo">moveTo</a><br/><a href="#updateAnimation">updateAnimation</a><br/><a href="#stopAnimation">stopAnimation</a><br/><a href="#getPanel">getPanel</a><br/><a href="#enableInput">enableInput</a><br/><a href="#disableInput">disableInput</a><br/><a href="#getStatus">getStatus</a><br/><a href="#setStatus">setStatus</a><br/><a href="#addPlugins">addPlugins</a><br/><a href="#removePlugins">removePlugins</a><br/><a href="#resize">resize</a><br/><a href="#append">append</a><br/><a href="#prepend">prepend</a><br/><a href="#insert">insert</a><br/><a href="#remove">remove</a><br/><a href="#trigger">trigger</a><br/><a href="#once">once</a><br/><a href="#hasOn">hasOn</a><br/><a href="#on">on</a><br/><a href="#off">off</a></div><div className="col col--4"><a href="#event-ready">ready</a><br/><a href="#event-beforeResize">beforeResize</a><br/><a href="#event-afterResize">afterResize</a><br/><a href="#event-holdStart">holdStart</a><br/><a href="#event-holdEnd">holdEnd</a><br/><a href="#event-moveStart">moveStart</a><br/><a href="#event-move">move</a><br/><a href="#event-moveEnd">moveEnd</a><br/><a href="#event-willChange">willChange</a><br/><a href="#event-changed">changed</a><br/><a href="#event-willRestore">willRestore</a><br/><a href="#event-restored">restored</a><br/><a href="#event-select">select</a><br/><a href="#event-needPanel">needPanel</a><br/><a href="#event-visibleChange">visibleChange</a><br/><a href="#event-reachEdge">reachEdge</a><br/><a href="#event-panelChange">panelChange</a></div></div>
 </div>
 
 ## constructor
@@ -1204,6 +1204,183 @@ Remove the panel at the given index<br />This will decrease index of panels afte
 |:---:|:---:|:---:|:---:|:---:|
 |index|number|||Index of panel to remove|
 |deleteCount|number|✔️|1|Number of panels to remove from index|
+
+### trigger {#trigger}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+Trigger a custom event.
+
+**Returns**: this
+- An instance of the component itself
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|event|string \| ComponentEvent|||The name of the custom event to be triggered or an instance of the ComponentEvent|
+|params|Array&lt;any&gt; \| $ts:...|||Event data to be sent when triggering a custom event|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  beforeHi: ComponentEvent<{ foo: number; bar: string }>;
+  hi: { foo: { a: number; b: boolean } };
+  someEvent: (foo: number, bar: string) => void;
+  someOtherEvent: void; // When there's no event argument
+}> {
+  some(){
+    if(this.trigger("beforeHi")){ // When event call to stop return false.
+      this.trigger("hi");// fire hi event.
+    }
+  }
+}
+
+const some = new Some();
+some.on("beforeHi", e => {
+  if(condition){
+    e.stop(); // When event call to stop, `hi` event not call.
+  }
+  // `currentTarget` is component instance.
+  console.log(some === e.currentTarget); // true
+
+  typeof e.foo; // number
+  typeof e.bar; // string
+});
+some.on("hi", e => {
+  typeof e.foo.b; // boolean
+});
+// If you want to more know event design. You can see article.
+// https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
+```
+
+### once {#once}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+Executed event just one time.
+
+**Returns**: this
+- An instance of the component itself
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||The name of the event to be attached or an event name - event handler mapped object.|
+|handlerToAttach|function \| $ts:...|✔️||The handler function of the event to be attached|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: ComponentEvent;
+}> {
+  hi() {
+    alert("hi");
+  }
+  thing() {
+    this.once("hi", this.hi);
+  }
+}
+
+var some = new Some();
+some.thing();
+some.trigger(new ComponentEvent("hi"));
+// fire alert("hi");
+some.trigger(new ComponentEvent("hi"));
+// Nothing happens
+```
+
+### hasOn {#hasOn}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+Checks whether an event has been attached to a component.
+
+**Returns**: boolean
+- Indicates whether the event is attached.
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string|||The name of the event to be attached|
+
+```ts
+import Component from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  some() {
+    this.hasOn("hi");// check hi event.
+  }
+}
+```
+
+### on {#on}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+Attaches an event to a component.
+
+**Returns**: this
+- An instance of a component itself
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|||The name of the event to be attached or an event name - event handler mapped object.|
+|handlerToAttach|function \| $ts:...|✔️||The handler function of the event to be attached|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.on("hi",this.hi); //attach event
+  }
+}
+```
+
+### off {#off}
+
+<div>
+  <span className="badge badge--danger">inherited</span>
+</div>
+
+Detaches an event from the component.<br/>If the `eventName` is not given this will detach all event handlers attached.<br/>If the `handlerToDetach` is not given, this will detach all event handlers for `eventName`.
+
+**Returns**: this
+- An instance of a component itself
+
+|PARAMETER|TYPE|OPTIONAL|DEFAULT|DESCRIPTION|
+|:---:|:---:|:---:|:---:|:---:|
+|eventName|string \| $ts:...|✔️||The name of the event to be detached|
+|handlerToDetach|function \| $ts:...|✔️||The handler function of the event to be detached|
+
+```ts
+import Component, { ComponentEvent } from "@egjs/component";
+
+class Some extends Component<{
+  hi: void;
+}> {
+  hi() {
+    console.log("hi");
+  }
+  some() {
+    this.off("hi",this.hi); //detach event
+  }
+}
+```
 
 ## Events
 ### ready {#event-ready}

--- a/docs/versioned_sidebars/version-4.10.7-sidebars.json
+++ b/docs/versioned_sidebars/version-4.10.7-sidebars.json
@@ -32,7 +32,8 @@
         "api/VirtualPanel",
         "api/ExternalRenderer",
         "api/Renderer",
-        "api/VanillaRenderer"
+        "api/VanillaRenderer",
+        "api/Component"
       ]
     },
     {


### PR DESCRIPTION
## Issue
#791 

## Details

![image](https://user-images.githubusercontent.com/13797320/233283213-36ab4995-70a9-4d4b-a966-ce329baca4f0.png)
https://malangfox.github.io/egjs-flicking/Demos#variable-size-panels

This adds a link to the circular option in the first circular Demo area of the documentation.
When checking the implementation demo of the `circular` option, it is recommended that users note the warning statement related to the size of the Panel.

In addition, this adds the missing documentation pages found in #798.