### PR TITLE
docs: update documentation link to newest at bottom of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ var flicking = new Flicking("#my-flicking", { circular: true });
 Check our [Demos](https://naver.github.io/egjs-flicking/).
 
 ## 📖 Documentation
-See [Documentation](https://naver.github.io/egjs-flicking/release/latest/doc/index.html) page.
+See [Documentation](https://naver.github.io/egjs-flicking/docs/api/Flicking) page.
 
 ## 🙌 Contributing
 See [CONTRIBUTING.md](https://github.com/naver/egjs-flicking/blob/master/CONTRIBUTING.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@egjs/flicking",
-	"version": "4.10.6-snapshot",
+	"version": "4.10.7-snapshot",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@egjs/flicking",
-			"version": "4.10.6-snapshot",
+			"version": "4.10.7-snapshot",
 			"license": "MIT",
 			"dependencies": {
 				"@egjs/axes": "^3.8.3",

--- a/packages/ngx-flicking/README.md
+++ b/packages/ngx-flicking/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align=center>
-  <a href="https://codesandbox.io/s/egjsngx-flicking-examples-czb2g">Demo</a> / <a href="https://naver.github.io/egjs-flicking/release/latest/doc/index.html">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
+  <a href="https://codesandbox.io/s/egjsngx-flicking-examples-czb2g">Demo</a> / <a href="https://naver.github.io/egjs-flicking/docs/api/Flicking">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
 </p>
 
 ## ⚙️ Installation

--- a/packages/ngx-flicking/projects/ngx-flicking/README.md
+++ b/packages/ngx-flicking/projects/ngx-flicking/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align=center>
-  <a href="https://codesandbox.io/s/egjsngx-flicking-examples-czb2g">Demo</a> / <a href="https://naver.github.io/egjs-flicking/release/latest/doc/index.html">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
+  <a href="https://codesandbox.io/s/egjsngx-flicking-examples-czb2g">Demo</a> / <a href="https://naver.github.io/egjs-flicking/docs/api/Flicking">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
 </p>
 
 ## ⚙️ Installation

--- a/packages/preact-flicking/README.md
+++ b/packages/preact-flicking/README.md
@@ -29,7 +29,7 @@
 </p>
 
 <p align=center>
-  <a href="https://naver.github.io/egjs-flicking/">Demo</a> / <a href="https://naver.github.io/egjs-flicking/release/latest/doc/index.html">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
+  <a href="https://naver.github.io/egjs-flicking/">Demo</a> / <a href="https://naver.github.io/egjs-flicking/docs/api/Flicking">Documentation</a> / <a href="https://naver.github.io/egjs/" />Other components</a>
 </p>
 
 ## ⚙️ Installation


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
There are two `Documentation` links in the README.md, the one at the bottom is outdated.  

I found the old links in the README.md of the root, ngx, and preact packages and fixed them with the newer links that were changed in 4.x.
