### PR TITLE
fix: add missing styleUrls in ngx-flicking

### DIFF
--- a/packages/ngx-flicking/projects/demo/src/app/app.module.ts
+++ b/packages/ngx-flicking/projects/demo/src/app/app.module.ts
@@ -71,7 +71,7 @@ const appRoutes: Routes = [
   imports: [
     BrowserModule,
     NgxFlickingModule,
-    RouterModule.forRoot(appRoutes, { enableTracing: false, relativeLinkResolution: 'legacy' })
+    RouterModule.forRoot(appRoutes, { enableTracing: false })
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/packages/ngx-flicking/projects/ngx-flicking/src/lib/ngx-flicking.component.ts
+++ b/packages/ngx-flicking/projects/ngx-flicking/src/lib/ngx-flicking.component.ts
@@ -72,6 +72,9 @@ import NgxElementProvider from './NgxElementProvider';
     class: 'flicking-viewport',
     style: 'display: block;',
   },
+  styleUrls: [
+    "../../node_modules/@egjs/flicking/dist/flicking.css"
+  ],
   encapsulation: ViewEncapsulation.None,
   standalone: true,
   imports: [CommonModule],


### PR DESCRIPTION
## Issue
#815

