### PR TITLE
fix: strict movetype moving wrong panel on circular flicking

### DIFF
--- a/src/control/Control.ts
+++ b/src/control/Control.ts
@@ -23,6 +23,7 @@ abstract class Control {
   protected _flicking: Flicking | null;
   protected _controller: AxesController;
   protected _activePanel: Panel | null;
+  protected _nextPanel: Panel | null;
 
   /**
    * A controller that handles the {@link https://naver.github.io/egjs-axes/ @egjs/axes} events
@@ -317,6 +318,7 @@ abstract class Control {
     const flicking = getFlickingAttached(this._flicking);
 
     this._activePanel = newActivePanel;
+    this._nextPanel = null;
 
     flicking.camera.updateAdaptiveHeight();
 
@@ -357,6 +359,8 @@ abstract class Control {
       isTrusted: axesEvent?.isTrusted || false,
       direction: getDirection(activePanel?.position ?? camera.position, position)
     });
+
+    this._nextPanel = panel;
     flicking.trigger(event);
 
     if (event.isCanceled()) {

--- a/src/control/StrictControl.ts
+++ b/src/control/StrictControl.ts
@@ -190,7 +190,7 @@ class StrictControl extends Control {
   public moveToPosition(position: number, duration: number, axesEvent?: OnRelease) {
     const flicking = getFlickingAttached(this._flicking);
     const camera = flicking.camera;
-    const activePanel = this._activePanel;
+    const currentPanel = this._nextPanel ?? this._activePanel;
     const axesRange = this._controller.range;
     const indexRange = this._indexRange;
     const cameraRange = camera.range;
@@ -199,11 +199,11 @@ class StrictControl extends Control {
     const clampedPosition = clamp(camera.clampToReachablePosition(position), axesRange[0], axesRange[1]);
     const anchorAtPosition = camera.findAnchorIncludePosition(clampedPosition);
 
-    if (!anchorAtPosition || !activePanel) {
+    if (!anchorAtPosition || !currentPanel) {
       return Promise.reject(new FlickingError(ERROR.MESSAGE.POSITION_NOT_REACHABLE(position), ERROR.CODE.POSITION_NOT_REACHABLE));
     }
 
-    const prevPos = activePanel.position;
+    const prevPos = currentPanel.position;
     const posDelta = flicking.animating
       ? state.delta
       : position - camera.position;
@@ -233,7 +233,7 @@ class StrictControl extends Control {
 
       targetPanel = targetAnchor.panel;
       targetPos = targetAnchor.position;
-    } else if (isOverThreshold && anchorAtPosition.position !== activePanel.position) {
+    } else if (isOverThreshold && anchorAtPosition.position !== currentPanel.position) {
       // Move to anchor at position
       targetPanel = anchorAtPosition.panel;
       targetPos = anchorAtPosition.position;

--- a/test/unit/control/StrictControl.spec.ts
+++ b/test/unit/control/StrictControl.spec.ts
@@ -286,6 +286,19 @@ describe("StrictControl", () => {
         expect(moveSpy.calledTwice).to.be.true;
         expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
       });
+
+      it("should determine the next panel based on the target panel of the willChange event", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { moveType: MOVE_TYPE.STRICT, circular: true, duration: 5000, threshold: 0 });
+
+        await simulate(flicking.element, { deltaX: 900, duration: 100 }, 1000);
+        tick(500);
+        await simulate(flicking.element, { deltaX: 900, duration: 100 }, 1000);
+        tick(500);
+        await simulate(flicking.element, { deltaX: 900, duration: 100 }, 1000);
+        tick(5000);
+
+        expect(flicking.index).to.equal(0);
+      });
     });
   });
 });


### PR DESCRIPTION
## Issue
#841 

## Details

![ezgif com-video-to-gif (2)](https://github.com/naver/egjs-flicking/assets/13797320/b6b2804e-a3ea-4e38-ae62-47247f9cb136)

When using the next Panel to move in `moveType: strict`, we use the following rules

1. find the `anchorAtPosition` that is closest to the point the camera is currently showing.
2. if `anchorAtPosition` is not the same as Flicking's current Panel, we move to anchorAtPosition.
3. if `anchorAtPosition` is the same as Flicking's current Panel, navigate to `adjacentAnchor` which is the next/prev anchor of `anchorAtPosition`.

However, there is an exception to this rule that can cause an error when you rotate the circular Flicking once before the event that updates the current panel is fired,  

If you rotate the Flicking once, you'll end up in a situation where the camera is showing the position of the current panel again.

If that happens, you won't be able to stop on that panel by step 3 and you'll move to the next Anchor.
This will cause the error described in the issue.

In this PR, I have fixed `moveType: strict` to continuously update the current Panel based on the `willChange` event to prevent the above exception from occurring.