### PR TITLE
fix: add findActiveAnchor fallback for bound flicking

### DIFF
--- a/src/camera/Camera.ts
+++ b/src/camera/Camera.ts
@@ -404,9 +404,11 @@ class Camera {
    */
   public findActiveAnchor(): AnchorPoint | null {
     const flicking = getFlickingAttached(this._flicking);
-    const activeIndex = flicking.control.activeIndex;
+    const activePanel = flicking.control.activePanel;
 
-    return find(this._anchors, anchor => anchor.panel.index === activeIndex);
+    if (!activePanel) return null;
+
+    return find(this._anchors, anchor => anchor.panel.index === activePanel.index) ?? this.findNearestAnchor(activePanel.position);
   }
 
   /**

--- a/test/unit/control/SnapControl.spec.ts
+++ b/test/unit/control/SnapControl.spec.ts
@@ -283,7 +283,7 @@ describe("SnapControl", () => {
         expect(position).to.equal(flicking.panels[0].position);
       });
 
-      it("Should move to the nearest panel from the camera, when animation is interrupted by user input", async () => {
+      it("should move to the nearest panel from the camera, when animation is interrupted by user input", async () => {
         const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, {
           moveType: MOVE_TYPE.SNAP,
           align: "prev",
@@ -304,6 +304,29 @@ describe("SnapControl", () => {
 
         expect(moveSpy.calledTwice).to.be.true;
         expect(control.activePanel.index).to.equal(camera.findNearestAnchor(position).panel.index);
+      });
+
+      it("should use the closest anchor even if there is no anchor for the active panel.", async () => {
+        const flicking = await createFlicking(
+          El.viewport().add(
+            El.camera()
+              .add(El.panel(`33%`))
+              .add(El.panel(`33%`))
+              .add(El.panel(`33%`))
+              .add(El.panel(`33%`))
+          ), {
+            moveType: MOVE_TYPE.SNAP,
+            bound: true // when bound is true, there is no anchor for first panel
+          }
+        );
+
+        // Set active panel to first panel
+        void flicking.moveTo(0, 0);
+        await simulate(flicking.element, { deltaX: -1000, duration: 100 });
+
+        const status = flicking.getStatus();
+
+        expect(status.index).equals(2);
       });
     });
   });


### PR DESCRIPTION
## Issue
#850

https://codepen.io/malangfox/pen/WNmPemg
Pressing the moveTo button, opening the console, and dragging the flicking should reproduce it.

## Details

Position is not reachable error occurs when using the `moveTo` method for the first panel with `bound: true`.

![image](https://github.com/naver/egjs-flicking/assets/13797320/7f74f2c8-491a-4257-9e31-ed99b38574e6)

In the above demo, when 4 Panels are placed, the total number of Anchors is 2.

This is because the Panel labeled 1 and the Panel labeled 2 share the same Anchor point.
Similarly, the panel with 3 and the panel with 4 share the same anchor point.

This is because there is no way to send Panels 1 / 4 to the center with the bound option enabled, which removes the left and right empty spaces.

This means that in this situation, only the Anchor points of Panel 2 and Panel 3 exist.

If we use the `moveTo` method with Panel 1, the Anchor point we stop at is the Anchor of Panel 2, but the index of the active Panel in the flicking will be the first Panel.

In this situation, `moveToPosition`, which calculates the arrival point at the end of a drag with `moveType: "snap"`, has the following logic.

```ts
const activeAnchor = camera.findActiveAnchor();
const anchorAtCamera = camera.findNearestAnchor(camera.position);
if (!activeAnchor || !anchorAtCamera) {
  return Promise.reject(new FlickingError(...));
}
```

and `findActiveAnchor` behaves as follows.

```ts
public findActiveAnchor(): AnchorPoint | null {
  const flicking = getFlickingAttached(this._flicking);
  const activeIndex = flicking.control.activeIndex;

  return find(this._anchors, anchor => anchor.panel.index === activeIndex);
}
```


The `activeIndex` is Panel 1, but none of the anchors corresponds to Panel 1, so it returns null.

Since `activeAnchor` is null, an error message is raised via Promise.reject.

I handled the exception of the `findActiveAnchor` by returning the closest Anchor to the active panel's position as a fallback if no corresponding Anchor for the active panel exists.