### PR TITLE
fix: Add check before update

### DIFF
--- a/packages/vue3-flicking/src/Flicking.ts
+++ b/packages/vue3-flicking/src/Flicking.ts
@@ -135,7 +135,7 @@ const Flicking = defineComponent({
   beforeUpdate() {
     this.fillKeys();
 
-    this.diffResult = this.slotDiffer.update(this.getSlots());
+    this.diffResult = this.slotDiffer?.update(this.getSlots());
   },
   updated() {
     const flicking = this.vanillaFlicking;


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->

## Details
Sometimes when mounting and unmounting different instances of Flicking slider, variable this.slotDiffer is undefined, throwing an exception on beforeUpdate() execution.
This fix is just to avoid the exception. 
