### PR TITLE
add preventDefaultOnDrag to quickstart's example

### DIFF
--- a/docs/docs/tutorials/quick-start.mdx
+++ b/docs/docs/tutorials/quick-start.mdx
@@ -299,7 +299,7 @@ You should add directive `flicking-panel` to the panel elements you use
 
 ```html
 <ngx-flicking
-  [options]="{ circular: true, duration: 500 }"
+  [options]="{ circular: true, duration: 500, preventDefaultOnDrag: true }"
   [plugins]="plugins"
   (needPanel)="onNeedPanel($event)"
   (moveEnd)="onMoveEnd($event)"


### PR DESCRIPTION
## Issue
https://github.com/naver/egjs-flicking/issues/894

## Details
This solves the issue that new users of egjs-flicking may find if following the docs for quickstart located here https://naver.github.io/egjs-flicking/docs/quick-start