### PR TITLE
docs: Fix typo in korean Flicking.mdx

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.11.4/api/Flicking.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.11.4/api/Flicking.mdx
@@ -611,7 +611,7 @@ const flicking = new Flicking({
 
 </div>
 
-Flicking이 최대 영역을 넘어서 갈 수 있는 최대 크기. `circular=false`인 경우에만 사용할 수 있습니다.<br />배열을 통해 prev/next 방향에 대해 서로 다른 바운스 값을 지정할 수 있습니다.<br />`number`를 통해 px값을, `stirng`을 통해 px 혹은 뷰포트 크기 대비 %값을 사용할 수 있습니다.<br />이 값을 변경시 [Control#updateInput](Control#updateInput)를 호출해야 합니다.
+Flicking이 최대 영역을 넘어서 갈 수 있는 최대 크기. `circular=false`인 경우에만 사용할 수 있습니다.<br />배열을 통해 prev/next 방향에 대해 서로 다른 바운스 값을 지정할 수 있습니다.<br />`number`를 통해 px값을, `string`을 통해 px 혹은 뷰포트 크기 대비 %값을 사용할 수 있습니다.<br />이 값을 변경시 [Control#updateInput](Control#updateInput)를 호출해야 합니다.
 
 **Type**: string \| number \| Array&lt;(string\|number)&gt;
 


### PR DESCRIPTION
fix typo

`stirng` => `string`
