### PR TITLE
fix: check other props for react state change

### DIFF
--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -266,11 +266,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
     const same = prevChildren.every((child, idx) => {
       const nextChild = nextChildren[idx];
 
-      if (child.key && nextChild.key) {
-        return child.key === nextChild.key && Object.keys(child.props).every(key => child.props[key] === nextChild.props[key]);
-      } else {
-        return child === nextChild;
-      }
+      return child === nextChild;
     });
 
     return same;

--- a/packages/react-flicking/src/react-flicking/Flicking.tsx
+++ b/packages/react-flicking/src/react-flicking/Flicking.tsx
@@ -267,7 +267,7 @@ class Flicking extends React.Component<Partial<FlickingProps & FlickingOptions>>
       const nextChild = nextChildren[idx];
 
       if (child.key && nextChild.key) {
-        return child.key === nextChild.key;
+        return child.key === nextChild.key && Object.keys(child.props).every(key => child.props[key] === nextChild.props[key]);
       } else {
         return child === nextChild;
       }


### PR DESCRIPTION
## Issue
https://github.com/naver/egjs-flicking/issues/905

## Details
Checks all props when determining whether the panel's state is updated.