### PR TITLE
fix: error on removePanel for unseen panel

### DIFF
--- a/packages/flicking/src/renderer/Renderer.ts
+++ b/packages/flicking/src/renderer/Renderer.ts
@@ -607,7 +607,11 @@ abstract class Renderer {
     const cameraElement = flicking.camera.element;
 
     panels.forEach(panel => {
-      cameraElement.removeChild(panel.element);
+      // With `renderOnlyVisible`, non-visible panels are detached from the camera element,
+      // so only remove elements that are actually mounted to avoid a `removeChild` error.
+      if (panel.element.parentNode === cameraElement) {
+        cameraElement.removeChild(panel.element);
+      }
     });
   }
 

--- a/packages/test-flicking/unit/renderer/Renderer.spec.ts
+++ b/packages/test-flicking/unit/renderer/Renderer.spec.ts
@@ -237,6 +237,30 @@ describe("Renderer", () => {
         expect(panelChangeSpy.mock.calls[0][0].removed.length).toBe(1);
         expect(panelChangeSpy.mock.calls[0][0].removed[0]).toEqual(prevPanels[1]);
       });
+
+      it("should actually remove a panel whose element is detached (renderOnlyVisible)", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const renderer = new RendererImpl().init(flicking);
+        const prevPanelCount = renderer.panelCount;
+        const targetPanel = renderer.panels[prevPanelCount - 1];
+        const targetElement = targetPanel.element;
+
+        targetPanel.markForHide();
+        expect(targetPanel.rendered).toBe(false);
+        expect(targetElement.parentNode).toBe(null);
+
+        let removed: Panel[] = [];
+        expect(() => {
+          removed = renderer.batchRemove({ index: prevPanelCount - 1, deleteCount: 1, hasDOMInElements: true });
+        }).not.toThrow();
+
+        expect(removed.length).toBe(1);
+        expect(removed[0]).toBe(targetPanel);
+        expect(targetPanel.removed).toBe(true);
+        expect(renderer.panelCount).toBe(prevPanelCount - 1);
+        expect(renderer.panels.includes(targetPanel)).toBe(false);
+        expect(flicking.camera.element.contains(targetElement)).toBe(false);
+      });
     });
 
     describe("updatePanelSize", () => {


### PR DESCRIPTION
## Details
https://naver.github.io/egjs-flicking/docs/demos/advanced/add-remove

In a vanilla environment, calling `removeChild` on an invisible panel causes an error when the `renderOnlyVisible` option is used.

<img width="485" height="328" alt="스크린샷 2026-07-08 오후 9 57 11" src="https://github.com/user-attachments/assets/813bbbe9-d557-41c7-b148-d5684e374292" />
<img width="482" height="322" alt="스크린샷 2026-07-08 오후 9 57 14" src="https://github.com/user-attachments/assets/bc883dd0-c912-426a-b5cf-b2e22c3502dd" />

This error is resolved by adding logic to handle DOM node detachment and panel removal separately.
In a framework environment, this error does not occur because DOM manipulation relies on the framework.