### PR TITLE
fix: error on insert for unseen panel

### DIFF
--- a/packages/flicking/src/renderer/Renderer.ts
+++ b/packages/flicking/src/renderer/Renderer.ts
@@ -594,7 +594,13 @@ abstract class Renderer {
     const fragment = document.createDocumentFragment();
 
     panels.forEach(panel => fragment.appendChild(panel.element));
-    cameraElement.insertBefore(fragment, nextSiblingElement);
+
+    // With `renderOnlyVisible`, the reference(nextSibling) panel may be detached from the camera
+    // element. insertBefore requires the reference to be a mounted child, so fall back to appending
+    // when it isn't to avoid a `NotFoundError`.
+    const referenceElement =
+      nextSiblingElement && nextSiblingElement.parentNode === cameraElement ? nextSiblingElement : null;
+    cameraElement.insertBefore(fragment, referenceElement);
   }
 
   /**

--- a/packages/test-flicking/e2e/tests/advanced/add-remove/add-remove.spec.ts
+++ b/packages/test-flicking/e2e/tests/advanced/add-remove/add-remove.spec.ts
@@ -40,6 +40,22 @@ for (const framework of spec.frameworks) {
       expect(state.panelCount).toBe(6);
     });
 
+    // focus: Prepend 연타 시 renderOnlyVisible로 detach된 패널 참조 insertBefore 에러 없음 (회귀)
+    test("Prepend 연타 시 에러 없이 패널 추가", async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on("pageerror", e => pageErrors.push(e.message));
+
+      const prependBtn = page.locator("button", { hasText: "Prepend" });
+      for (let i = 0; i < 3; i++) {
+        await prependBtn.click();
+        await page.waitForTimeout(300);
+      }
+
+      expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+      const state = await getFlickingState(page);
+      expect(state.panelCount).toBe(8);
+    });
+
     // focus: Remove 버튼 클릭 시 패널 삭제
     test("Remove로 패널 삭제", async ({ page }) => {
       const removeLastBtn = page.locator("button", { hasText: "Remove Last" });

--- a/packages/test-flicking/unit/renderer/Renderer.spec.ts
+++ b/packages/test-flicking/unit/renderer/Renderer.spec.ts
@@ -185,6 +185,29 @@ describe("Renderer", () => {
 
         expect(checkPanelContentsReadySpy).toHaveBeenCalledWith(newPanels);
       });
+
+      it("should insert a panel even when the reference(nextSibling) element is detached (renderOnlyVisible)", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const renderer = new RendererImpl().init(flicking);
+        const prevPanelCount = renderer.panelCount;
+
+        // renderOnlyVisible detaches non-visible panels; make the prepend reference (first panel) detached
+        const refPanel = renderer.panels[0];
+        const refElement = refPanel.element;
+        refPanel.markForHide();
+        expect(refElement.parentNode).toBe(null);
+
+        const newElement = El.panel().el;
+
+        let inserted: Panel[] = [];
+        expect(() => {
+          inserted = renderer.batchInsert({ index: 0, elements: [newElement], hasDOMInElements: true });
+        }).not.toThrow();
+
+        expect(inserted.length).toBe(1);
+        expect(renderer.panelCount).toBe(prevPanelCount + 1);
+        expect(flicking.camera.element.contains(newElement)).toBe(true);
+      });
     });
 
     describe("batchRemove", () => {


### PR DESCRIPTION
### 문제

- `renderOnlyVisible` 사용 시 안 보이는 패널은 camera element에서 detach됨
- `prepend`(또는 특정 위치 insert)를 반복하면 삽입 기준(`nextSibling`) 패널이 detach 상태일 수 있음
- `_insertPanelElements`의 `insertBefore(fragment, nextSiblingElement)`가 미마운트 참조를 받아 `NotFoundError: ... not a child of this node` 발생
- add-remove 데모에서 **Prepend 2회 이상** 클릭 시 재현

### 원인

- #946은 대칭 경로인 `_removePanelElements`의 `removeChild`만 가드했고, `_insertPanelElements`의 `insertBefore`는 미가드로 남아 있었음

### 수정

- 기준(`nextSibling`) 요소가 camera element의 실제 자식일 때만 참조로 사용, 아니면 `null`로 폴백(append) → `insertBefore` 에러 회피 (#946과 동일 스타일 가드)

### 회귀 테스트

- unit(`Renderer.spec.ts`): detach된 참조로 `batchInsert` 시 throw 없음 (수정 전 동일 에러 재현 확인)
- e2e(`add-remove`): Prepend 연타 시 pageerror 없음 + 패널 수 검증

### Test plan

- [x] unit 통과 (575, +1)
- [x] e2e 통과 (453, +3)
- [ ] 리뷰 후 master 머지 → 4.16.3 패치 배포

🤖 Generated with [Claude Code](https://claude.com/claude-code)
