### PR TITLE
docs: improve README links and version display

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 </p>
 
 <h3 align="center">
-  <a href="https://naver.github.io/egjs-flicking/">Demo</a> / <a href="https://naver.github.io/egjs-flicking/docs/api/Flicking">Documentation</a> / <a href="https://naver.github.io/egjs/"><img height="20" src="https://naver.github.io/egjs/img/logo.svg"/> Other components</a>
+  <a href="https://naver.github.io/egjs-flicking/docs/demos/basic/default">Demo</a> / <a href="https://naver.github.io/egjs-flicking/docs/guide/quickstart">Guide</a> / <a href="https://naver.github.io/egjs-flicking/docs/api/classes/Flicking">API</a> / <a href="https://naver.github.io/egjs/"><img height="20" src="https://naver.github.io/egjs/img/logo.svg"/> Other components</a>
 </h3>
 
 <p align="center">
@@ -44,7 +44,7 @@
   </tbody>
 </table>
 <h6 align="center">
-  🖱️Click each images to see its source or check our <a href="https://naver.github.io/egjs-flicking/">full demos</a>.
+  🖱️Click each images to see its source or check our <a href="https://naver.github.io/egjs-flicking/docs/demos/basic/default">full demos</a>.
 </h6>
 
 ## ✨ Features
@@ -118,9 +118,12 @@ This repository is a monorepo that contains Flicking and all its related package
 
 egjs is investing in an **AI-native** development experience — use-case-centered documentation, stronger TypeScript types, clearer error messages, and predictable internals to help both humans and AI agents use Flicking correctly.
 
+See the [llms.txt guide](https://naver.github.io/egjs-flicking/docs/guide/llms) for how to feed Flicking's documentation to LLMs and AI agents.
+
 ## 📖 Documentation & Demos
-- [Demos](https://naver.github.io/egjs-flicking/) — includes an embedded **live code editor** for interactive exploration
-- [API Documentation](https://naver.github.io/egjs-flicking/docs/api/Flicking)
+- [Demos](https://naver.github.io/egjs-flicking/docs/demos/basic/default) — includes an embedded **live code editor** for interactive exploration
+- [Guide](https://naver.github.io/egjs-flicking/docs/guide/quickstart)
+- [API](https://naver.github.io/egjs-flicking/docs/api/classes/Flicking)
 
 ## 🙌 Contributing
 See [CONTRIBUTING.md](https://github.com/naver/egjs-flicking/blob/master/CONTRIBUTING.md). Please file issues on [GitHub](https://github.com/naver/egjs-flicking/issues).

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -1,7 +1,12 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Config } from "@docusaurus/types";
 import { themes } from "prism-react-renderer";
 import remarkBreaks from "remark-breaks";
+
+const flickingVersion = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "../flicking/package.json"), "utf-8")
+).version;
 
 export default {
   title: "Flicking",
@@ -97,7 +102,7 @@ export default {
           label: "Version",
           position: "right",
           items: [
-            { label: "Current", to: "/docs/guide/quickstart" },
+            { label: `Current (${flickingVersion})`, to: "/docs/guide/quickstart" },
             { label: "3.x", href: "https://naver.github.io/egjs-flicking/release/3.8.2/doc/index.html" }
           ]
         },

--- a/packages/docs/scripts/fetch-releases.js
+++ b/packages/docs/scripts/fetch-releases.js
@@ -59,7 +59,11 @@ async function main() {
   for (const release of releases) {
     if (release.draft) continue;
 
+    // 파일명은 가독성을 위해 날짜만 사용하고(':' 는 파일명에 부적합),
+    // frontmatter의 date는 전체 타임스탬프를 사용해 같은 날 여러 릴리즈의
+    // 선후 순서를 초 단위까지 구분한다. (날짜만 쓰면 정렬이 동점 처리됨)
     const date = release.published_at.slice(0, 10);
+    const publishedAt = release.published_at;
     const tag = release.tag_name;
     const filename = `release-${date}-${tag}.md`;
 
@@ -68,7 +72,7 @@ async function main() {
     const preview = fullChangelogIdx > 0 ? body.slice(0, fullChangelogIdx).trimEnd() : body;
     const rest = fullChangelogIdx > 0 ? body.slice(fullChangelogIdx) : "";
 
-    const parts = ["---", `title: "${tag}"`, `date: ${date}`, `tags: [release]`, "---", "", preview];
+    const parts = ["---", `title: "${tag}"`, `date: ${publishedAt}`, `tags: [release]`, "---", "", preview];
 
     if (rest) {
       parts.push("", "<!-- truncate -->", "", rest);


### PR DESCRIPTION
### README

- 데모 링크를 사이트 루트에서 데모 페이지로 교정
- Documentation 항목을 Guide / API로 분리, API 경로 교정
- AI Native 섹션에 llms.txt 가이드 링크 추가

### 문서 사이트

- 버전 드롭다운 Current 라벨에 현재 코어 버전 동적 표기
- 릴리즈 포스트 date에 전체 타임스탬프 사용해 같은 날 릴리즈 정렬 교정 (스크립트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)