### PR TITLE
fix: correct wrapper CJS interop breaking SSR

### DIFF
--- a/config/vite-build-helper.ts
+++ b/config/vite-build-helper.ts
@@ -113,7 +113,16 @@ function getBuildOptions(options: ViteConfigOptions): BuildOptions {
     rollupOptions: {
       external: Object.keys(external),
       output: {
-        globals: external
+        globals: external,
+        // Vite emits ESM-style CJS for each package (`exports.default = X` with
+        // `__esModule: true`). A default import of one egjs package from
+        // another (`import Flicking from "@egjs/flicking"`) must therefore be
+        // read through `.default` in the CJS/UMD bundles. "auto" injects the
+        // runtime `_interopDefault` check; without it the require result (the
+        // whole namespace object) is used as the class, so `VanillaFlicking.
+        // prototype` is undefined and SSR throws
+        // "Cannot use 'in' operator to search for 'autoResize' in undefined".
+        interop: "auto"
       }
     },
     minify: minify ? "terser" : false


### PR DESCRIPTION
### 요약
- egjs-flicking 4.16에서 빌드를 Vite로 전환하며 코어 CJS가 ESM 스타일로 출력됐는데, react/vue 래퍼가 interop 없이 이를 클래스로 바로 써서 SSR에서 VanillaFlicking.prototype이 undefined가 되어 에러 발생. 
- rollup 출력 옵션에 output.interop: "auto"를 추가해 default를 올바르게 추출하도록 수정
- react, vue 래퍼만 재배포 필요 

### 원인

- 4.16에서 빌드 시스템을 rollup(build-helper) → Vite로 전환.
- 코어 CJS 산출물이 ESM 스타일로 출력됨 (`Object.defineProperties(exports, { __esModule: { value: true } })` + `exports.default = Flicking`).
- 결과적으로 `require("@egjs/flicking")`가 Flicking 클래스가 아닌 모듈 객체(`{ __esModule: true, default: Flicking, ...named }`)를 반환.
- 반면 래퍼(react/vue) CJS 번들은 interop 없이 이 모듈 객체를 클래스로 직접 사용 (`const VanillaFlicking = require("@egjs/flicking")`).
- 래퍼 `render()`(SSR에서 실행되는 경로) 내 `name in VanillaFlicking.prototype` 검사에서 `VanillaFlicking.prototype`이 `undefined` → `TypeError: Cannot use 'in' operator to search for 'autoResize' in undefined` 발생.
- 코어 외부 의존성(`@egjs/axes`, `@egjs/component` 등)은 구식 CJS(`module.exports = class`)라 기존 interop으로도 정상 소비 → CSR은 정상, 래퍼→코어 CJS 소비만 실패하는 비대칭 상황.

### 해결

- 공유 빌드 헬퍼 `config/vite-build-helper.ts`의 rollup 출력에 `output.interop: "auto"` 추가.
- 래퍼 CJS 번들이 `_interopDefault`로 `__esModule` 여부를 런타임 판별하여 default import를 `.default`에서 올바르게 추출.
- 단일 지점 수정으로 react/vue/plugins 빌드에 일괄 반영.

### 영향 범위

- react/vue 래퍼 CJS/UMD 번들 재빌드 및 정식 재배포 필요.
- 코어(`@egjs/flicking`) CJS 산출물 자체는 정상이므로 코어 재배포 불필요.

### Test plan

- [x] react `renderToString` SSR 통과 (수정 전 재현 → 수정 후 해소)
- [x] unit / plugins / cfc 테스트 전체 통과
- [x] 베타(`@egjs/react-flicking@4.16.6-beta.0`) 배포 후 제보자 SSR 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
