### PR TITLE
fix: build core CJS from index.cjs.ts entry

### DIFF
--- a/config/verify-cjs-export.js
+++ b/config/verify-cjs-export.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015 NAVER Corp.
+ * egjs projects are licensed under the MIT license
+ */
+
+/**
+ * Guards the hybrid CJS export shape of the core bundle (see #952).
+ *
+ * The core CJS build must be produced from `src/index.cjs.ts`, which reassigns
+ * `module.exports` to the Flicking class with the named exports attached. If the
+ * build input silently reverts to the ESM entry (`src/index.ts`), `require()`
+ * returns a namespace object instead of the class and consumers doing
+ * `const F = require("@egjs/flicking"); new F()` break in CommonJS environments.
+ *
+ * Run against the built bundle (as a post-build step); asserts the contract and
+ * exits non-zero on violation so a broken bundle never gets published.
+ */
+const assert = require("assert");
+const path = require("path");
+
+const cjsPath = path.resolve(process.cwd(), "dist/flicking.cjs.js");
+
+const required = require(cjsPath);
+
+assert.strictEqual(
+  typeof required,
+  "function",
+  `require("@egjs/flicking") must return the Flicking class, got "${typeof required}". ` +
+    "The CJS build likely dropped src/index.cjs.ts as its entry."
+);
+assert.ok(required.prototype, "require() result must have a .prototype (it must be the class)");
+assert.strictEqual(required.default, required, "the .default export must self-reference the class");
+assert.ok(required.EVENTS, "named exports (e.g. EVENTS) must be attached to the class");
+
+console.log("✓ CJS export verified: require(\"@egjs/flicking\") returns the Flicking class");

--- a/packages/flicking/package.json
+++ b/packages/flicking/package.json
@@ -18,7 +18,7 @@
     "dev:preview": "vite --config vite.dev.config.ts --mode production",
     "build": "run-s build:bundle build:css build:declaration printsizes",
     "build:bundle": "rm -rf ./dist && run-s build:bundle:common build:bundle:umd",
-    "build:bundle:common": "vite build",
+    "build:bundle:common": "concurrently \"VITE_BUILD_FORMAT=esm vite build\" \"VITE_BUILD_FORMAT=cjs vite build\"",
     "build:bundle:umd": "concurrently \"VITE_BUILD_FORMAT=umd vite build\" \"VITE_BUILD_FORMAT=umd VITE_MINIFY=true vite build\" \"VITE_BUILD_FORMAT=umd VITE_RESOLVE=true vite build\" \"VITE_BUILD_FORMAT=umd VITE_RESOLVE=true VITE_MINIFY=true vite build\"",
     "build:css": "run-s build:css-clear build:sass build:css-prefix build:css-min",
     "build:css-clear": "rm -rf ./dist/*.css",

--- a/packages/flicking/package.json
+++ b/packages/flicking/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "vite --config vite.dev.config.ts",
     "dev:preview": "vite --config vite.dev.config.ts --mode production",
-    "build": "run-s build:bundle build:css build:declaration printsizes",
+    "build": "run-s build:bundle build:css build:declaration verify:cjs printsizes",
     "build:bundle": "rm -rf ./dist && run-s build:bundle:common build:bundle:umd",
     "build:bundle:common": "concurrently \"VITE_BUILD_FORMAT=esm vite build\" \"VITE_BUILD_FORMAT=cjs vite build\"",
     "build:bundle:umd": "concurrently \"VITE_BUILD_FORMAT=umd vite build\" \"VITE_BUILD_FORMAT=umd VITE_MINIFY=true vite build\" \"VITE_BUILD_FORMAT=umd VITE_RESOLVE=true vite build\" \"VITE_BUILD_FORMAT=umd VITE_RESOLVE=true VITE_MINIFY=true vite build\"",
@@ -26,6 +26,7 @@
     "build:css-prefix": "postcss dist/*.css --replace --use autoprefixer --no-map",
     "build:css-min": "postcss dist/*.css --ext .min.css --use postcss-clean -d dist/ --no-map",
     "build:declaration": "tsc -p tsconfig.declaration.json",
+    "verify:cjs": "node ../../config/verify-cjs-export.js",
     "css": "postcss css/*.css --use autoprefixer postcss-clean -d dist/ -m",
     "printsizes": "print-sizes ./dist --exclude=\\.map"
   },

--- a/packages/flicking/vite.config.ts
+++ b/packages/flicking/vite.config.ts
@@ -11,22 +11,31 @@ const external = {
 
 // Determine build target based on environment variables
 // usage examples:
-//   - vite build                                                   -> es, cjs
+//   - vite build (default)                                        -> flicking.esm.js (es)
+//   - VITE_BUILD_FORMAT=cjs vite build                           -> flicking.cjs.js (cjs)
 //   - VITE_BUILD_FORMAT=umd vite build                            -> flicking.js (umd)
 //   - VITE_BUILD_FORMAT=umd VITE_MINIFY=true vite build          -> flicking.min.js (umd minified)
 //   - VITE_BUILD_FORMAT=umd VITE_RESOLVE=true vite build         -> flicking.pkgd.js (umd packaged)
 //   - VITE_BUILD_FORMAT=umd VITE_RESOLVE=true VITE_MINIFY=true vite build -> flicking.pkgd.min.js (umd packaged minified)
 
-const buildFormat = process.env.VITE_BUILD_FORMAT || "common";
+const buildFormat = process.env.VITE_BUILD_FORMAT || "esm";
 const shouldMinify = process.env.VITE_MINIFY === "true";
 const shouldResolve = process.env.VITE_RESOLVE === "true";
 
 let input = "src/index.ts";
-let formats: any[] = ["es", "cjs"];
+let formats: any[] = ["es"];
 let buildExternal = external;
 let outputSuffix = "";
 
-if (buildFormat === "umd") {
+if (buildFormat === "cjs") {
+  // The CJS build uses a dedicated entry that re-assigns `module.exports` to
+  // the Flicking class (with named exports attached), so `require(pkg)` returns
+  // the class itself while `.default` / named / ESM interop keep resolving.
+  // Building CJS from `src/index.ts` (ESM entry) instead drops this and breaks
+  // `const F = require(pkg); new F()` in CommonJS environments (see #952).
+  input = "src/index.cjs.ts";
+  formats = ["cjs"];
+} else if (buildFormat === "umd") {
   input = "src/index.umd.ts";
   formats = ["umd"];
 


### PR DESCRIPTION
Closes #952

### 원인

- 4.16에서 코어 빌드가 Vite로 전환되며 **CJS 빌드 입력이 `src/index.ts`(ESM 공용 엔트리)로 바뀜**.
- 하이브리드 패턴(named export를 클래스에 부착 후 `module.exports = Flicking`)을 담은 `src/index.cjs.ts`가 vite.config·package.json 어디에서도 참조되지 않는 **고아 파일**이 됨.
- 그 결과 코어 CJS 출력이 `exports.default = Flicking` + `__esModule`만 남아, `require("@egjs/flicking")`가 클래스가 아닌 네임스페이스 객체를 반환.
- 4.15까지 동작하던 `const F = require("@egjs/flicking"); new F()` / `F.prototype` 사용처(CommonJS·서버 환경 직접 require)가 깨짐.

> Vite가 `module.exports = Flicking`을 제거한 것이 아니라, 그 코드가 담긴 `index.cjs.ts` 파일 자체가 빌드 입력에서 누락된 것.

### 해결

- 코어 `vite.config.ts`에서 CJS 빌드가 원래 의도대로 `src/index.cjs.ts`를 입력으로 쓰도록 복원.
- es/cjs를 분리된 invocation으로 빌드 (react/vue 래퍼와 동일한 패턴).
  - `build:bundle:common`: `VITE_BUILD_FORMAT=esm`(→ `index.ts`) + `VITE_BUILD_FORMAT=cjs`(→ `index.cjs.ts`) 동시 실행.
- 빌드 후처리(footer 주입)가 아니라 **기존 소스 엔트리를 살리는 방식**이라, 4.15와 정확히 동일한 산출물을 소스 코드로 명시.
- 빌드 파이프라인에 `verify:cjs` 가드 스텝 추가 — 빌드된 CJS를 실제 require하여 클래스 반환을 검증, 입력이 다시 `index.ts`로 되돌아가는 회귀를 빌드 시점에 차단.

### 검증

- 코어 CJS 출력: `module.exports = Flicking`(+ named 부착 루프) + `exports.default` 이중 패턴 = 4.15.0과 동일.
- 코어 `require()` 결과: `typeof === "function"`, `.prototype` 존재, `.default === 자기 자신`, named(`.EVENTS`/`.Camera`) 부착, `"autoResize" in prototype` 정상, `__esModule` 미포함(4.15와 동일).
- ESM(`flicking.esm.js`) 출력에는 `module.exports` 미포함 확인. UMD/선언 산출물 정상 생성.
- react 래퍼: 코어 CJS 엔트리 복원만으로 SSR `renderToString` 통과.
- `verify:cjs` 가드: 정상 빌드 통과 + `module.exports` 제거 시 AssertionError로 실패(가드 유효성 확인).
- unit / plugins / cfc 테스트 전체 통과.

### 관계 (#951 대체)

- 근본 원인은 생산자(코어)이므로 코어를 고치는 본 PR로 일원화.
- 래퍼 CJS interop을 손대던 #951은 본 PR로 정합성상 불필요해져 닫음 (래퍼는 4.15처럼 raw require로 하이브리드 코어를 소비).
- 방어는 문제 발생 지점(코어 출력)에 `verify:cjs`로 배치.

### Test plan

- [x] 코어 CJS `require()`가 클래스를 직접 반환 (`.prototype` / `new` / named / `.default`)
- [x] ESM 출력 무영향, UMD·선언 산출물 정상
- [x] react 래퍼 SSR `renderToString` 통과
- [x] `verify:cjs` 가드가 정상 통과 & 회귀 시 실패
- [x] unit / plugins / cfc 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
