### PR TITLE
fix: restore @egjs/imready dependency range to ^1.3.1

### DIFF
--- a/packages/flicking/package.json
+++ b/packages/flicking/package.json
@@ -10,7 +10,7 @@
     "@cfcs/core": "^0.1.0",
     "@egjs/axes": "^3.9.1",
     "@egjs/component": "^3.0.2",
-    "@egjs/imready": "^1.1.1",
+    "@egjs/imready": "^1.3.1",
     "@egjs/list-differ": "^1.0.1"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,7 +266,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.5
       '@egjs/imready':
-        specifier: ^1.1.1
+        specifier: ^1.3.1
         version: 1.4.2
       '@egjs/list-differ':
         specifier: ^1.0.1


### PR DESCRIPTION
### 원인

- 4.16 pnpm 모노레포 이관 커밋(`ad5e4576d`)에서 코어 `@egjs/flicking`의 `@egjs/imready` 의존성 하한이 **4.15.0의 `^1.3.1`에서 `^1.1.1`로 낮아짐**.
- 소스 사용처(`packages/flicking/src/renderer/Renderer.ts`)는 `new ImReady()` / `.on()` / `.check()` 기본 API만 써서 컴파일 실패급 문제는 아님.
- 다만 하한이 낮아지면 소비자 의존성 트리에 낡은 imready(1.1.x/1.2.x)가 있을 때 dedupe로 구버전에 물릴 수 있어, **4.15 대비 의도치 않은 다운그레이드 여지**가 생김.

### 해결

- `packages/flicking/package.json`: `@egjs/imready` `^1.1.1` → `^1.3.1` (4.15.0 패리티 복원).
- lockfile 해석 버전은 `1.4.2`로 불변(`^1.3.1` 만족) — specifier 필드만 갱신.

### 검증

- [x] 4.15.0 루트 package.json 값(`^1.3.1`)과 일치 복원
- [x] lockfile specifier `^1.3.1` / resolved `1.4.2` 확인
- [x] 코어 imready 사용처가 1.3.x 이상 특정 API에 의존하지 않음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)