### PR TITLE
docs(publish): add mandatory docs:deploy step after release

### DIFF
--- a/dev-guide/PUBLISH_GUIDE.md
+++ b/dev-guide/PUBLISH_GUIDE.md
@@ -75,7 +75,12 @@ release/{scope}-{version}
 3. pnpm install 로 lockfile·심링크를 갱신한다. (버전 변경 후 필수)
    생략하면 래퍼 publish 단계에서 ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL로 중단된다.
 4. pnpm publish:stable 로 전체 빌드 + npm 퍼블리시한다.
-5. (선택) pnpm release 로 changelog, tag, GitHub Release를 생성한다.
+5. pnpm release 로 changelog·tag·push, gh release create 로 GitHub Release를 생성한다.
+6. pnpm docs:deploy 로 문서 사이트를 배포한다. (릴리즈 후 필수)
+   문서 사이트의 릴리즈 노트(/releases)·버전 표시는 빌드 시 GitHub Release를
+   가져와 갱신하므로, 릴리즈 노트 작성 후 문서를 배포하지 않으면 낡은 채 남는다.
+   ※ 이 클론처럼 origin이 정본(naver/egjs-flicking)이고 upstream 리모트가 없으면
+     pnpm docs:deploy-origin 을 사용한다. 상세 → DOCS_GUIDE.md "배포"
 ```
 
 ```bash
@@ -279,9 +284,12 @@ pnpm publish:version minor
 pnpm install
 # 4. 빌드 + 배포
 pnpm publish:stable
-# 5. 릴리즈 (선택)
+# 5. 릴리즈
 pnpm release
 gh release create "4.17.0" --title "4.17.0 Release" --generate-notes
+# 6. 문서 사이트 배포 (릴리즈 후 필수 — /releases·버전 표시 갱신)
+#    origin이 정본이고 upstream 리모트가 없으면 docs:deploy-origin 사용
+pnpm docs:deploy
 ```
 
 #### 코어 patch 정식 배포

--- a/dev-guide/PUBLISH_GUIDE.md
+++ b/dev-guide/PUBLISH_GUIDE.md
@@ -79,8 +79,9 @@ release/{scope}-{version}
 6. pnpm docs:deploy 로 문서 사이트를 배포한다. (릴리즈 후 필수)
    문서 사이트의 릴리즈 노트(/releases)·버전 표시는 빌드 시 GitHub Release를
    가져와 갱신하므로, 릴리즈 노트 작성 후 문서를 배포하지 않으면 낡은 채 남는다.
-   ※ 이 클론처럼 origin이 정본(naver/egjs-flicking)이고 upstream 리모트가 없으면
-     pnpm docs:deploy-origin 을 사용한다. 상세 → DOCS_GUIDE.md "배포"
+   ※ 배포 명령은 정본(naver/egjs-flicking)을 가리키는 리모트에 따라 고른다.
+     docs:deploy 는 upstream, docs:deploy-origin 은 origin에 배포한다.
+     상세 → DOCS_GUIDE.md "배포"
 ```
 
 ```bash
@@ -288,7 +289,7 @@ pnpm publish:stable
 pnpm release
 gh release create "4.17.0" --title "4.17.0 Release" --generate-notes
 # 6. 문서 사이트 배포 (릴리즈 후 필수 — /releases·버전 표시 갱신)
-#    origin이 정본이고 upstream 리모트가 없으면 docs:deploy-origin 사용
+#    정본을 가리키는 리모트에 따라 docs:deploy(upstream) 또는 docs:deploy-origin(origin)
 pnpm docs:deploy
 ```
 


### PR DESCRIPTION
### 배경

- 라이브러리 정식 배포·릴리즈 후 **문서 사이트 배포가 필수**임에도, `PUBLISH_GUIDE.md`의 배포 워크플로우에는 이 단계가 **필수 스텝으로 빠져** 있었음.
- 연동 메커니즘(`fetch-releases.js`가 GitHub Release를 가져와 `/releases`·버전 표시 갱신)은 `DOCS_GUIDE.md`에 있고, PUBLISH_GUIDE에는 260행 blockquote 곁주석으로만 언급됨.
- 그 결과 릴리즈 노트 작성 후 `docs:deploy`를 빠뜨리면 문서 사이트가 낡은 채로 남는 사고 여지가 있었음.

### 변경

- "정식 배포 (코어 변경)" 절차와 "코어 minor 정식 배포" 예시 양쪽에 **release 후 `pnpm docs:deploy` (릴리즈 후 필수)** 스텝 추가.
- origin이 정본(`naver/egjs-flicking`)이고 `upstream` 리모트가 없는 클론에서는 `pnpm docs:deploy-origin`을 쓰도록 주석 추가.
- 상세 파이프라인은 `DOCS_GUIDE.md` "배포"로 링크 (단일 출처 원칙 — 중복 서술 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)