### PR TITLE
fix: use cloneNode instead of innerHTML

### DIFF
--- a/packages/flicking/src/CrossFlicking.ts
+++ b/packages/flicking/src/CrossFlicking.ts
@@ -226,16 +226,17 @@ export class CrossFlicking extends Flicking {
 
   private _createCrossStructure(sideState: SideState[]) {
     const sideCamera = document.createElement("div");
-    let sidePanels: string = "";
 
     sideCamera.classList.add(CLASS.CAMERA);
+    // 이미 파싱된 DOM을 innerHTML/outerHTML 문자열로 직렬화 후 재파싱하면
+    // mXSS 페이로드가 실행될 수 있으므로 노드 복제로만 구조를 만든다
     sideState.forEach((state, i) => {
       const panel = this.camera.children[i];
-      sidePanels += state.element.innerHTML;
+      toArray(state.element.childNodes).forEach(child => {
+        sideCamera.appendChild(child.cloneNode(true));
+      });
       Array.from(panel.attributes).forEach(attribute => panel.removeAttribute(attribute.name));
     });
-
-    sideCamera.innerHTML = sidePanels;
 
     sideState.forEach((_, i) => {
       const panel = this.camera.children[i];
@@ -244,7 +245,10 @@ export class CrossFlicking extends Flicking {
           panel.classList.add(className);
         }
       });
-      panel.innerHTML = sideCamera.outerHTML;
+      while (panel.firstChild) {
+        panel.removeChild(panel.firstChild);
+      }
+      panel.appendChild(sideCamera.cloneNode(true));
     });
 
     this.element.setAttribute("data-cross-structure", "true");
@@ -271,7 +275,7 @@ export class CrossFlicking extends Flicking {
     return Object.keys(groupPanels).reduce((state: SideState[], key: string) => {
       const start = state.length ? +state[state.length - 1].end + 1 : 0;
       const element = groupPanels[key].reduce((el: HTMLElement, panel: HTMLElement) => {
-        el.innerHTML += panel.outerHTML;
+        el.appendChild(panel.cloneNode(true));
         return el;
       }, document.createElement("div"));
       return [

--- a/packages/flicking/src/Flicking.ts
+++ b/packages/flicking/src/Flicking.ts
@@ -560,6 +560,13 @@ export interface GetStatusParams {
   visiblePanelsOnly?: boolean;
 }
 
+// A cloned snapshot of each panel element captured by getStatus, keyed by the status panel entry.
+// setStatus restores panels by cloning these instead of re-parsing the serialized html string,
+// which would revive mutation-XSS payloads. Kept off the Status object so it stays a plain
+// JSON-serializable value; a JSON round-trip yields fresh entries that aren't in this map, so
+// panel DOM is left untouched. Weak keys let the snapshots be GC'd with their status entries.
+const panelSnapshots = new WeakMap<Status["panels"][0], HTMLElement>();
+
 class Flicking extends Component<FlickingEvents> {
   /**
    * Version info string
@@ -1810,6 +1817,9 @@ class Flicking extends Component<FlickingEvents> {
 
         if (includePanelHTML) {
           panelInfo.html = panel.element.outerHTML;
+          // Keep a cloned snapshot of the actual node (off the Status object, in panelSnapshots)
+          // so setStatus can restore panels by cloning it instead of re-parsing the html string.
+          panelSnapshots.set(panelInfo, panel.element.cloneNode(true) as HTMLElement);
         }
 
         return panelInfo;
@@ -1854,8 +1864,14 @@ class Flicking extends Component<FlickingEvents> {
     const renderer = this._renderer;
     const control = this._control;
 
-    // Can't add/remove panels on external rendering
-    if (panels[0]?.html && !this._renderExternal) {
+    // Rebuild panels only from the captured node snapshots by cloning them, never by re-parsing
+    // the serialized `html` string — an `outerHTML`→`innerHTML` round-trip can revive a
+    // mutation-XSS payload that was inert on first render. After a JSON round-trip the status
+    // entries are fresh objects absent from panelSnapshots, so panel DOM is left untouched (only
+    // index/position below are restored) instead of being reconstructed from the string.
+    // (Also can't add/remove panels on external rendering.)
+    const snapshots = panels.map(panel => panelSnapshots.get(panel));
+    if (snapshots[0] && !this._renderExternal) {
       renderer.batchRemove({
         index: 0,
         deleteCount: this.panels.length,
@@ -1863,7 +1879,7 @@ class Flicking extends Component<FlickingEvents> {
       });
       renderer.batchInsert({
         index: 0,
-        elements: parseElement(panels.map(panel => panel.html!)),
+        elements: snapshots.map(snapshot => snapshot!.cloneNode(true) as HTMLElement),
         hasDOMInElements: true
       });
     }

--- a/packages/flicking/src/Flicking.ts
+++ b/packages/flicking/src/Flicking.ts
@@ -33,7 +33,7 @@ import {
 } from "./renderer";
 import { ElementLike, MoveTypeOptions, Plugin, Status } from "./types/external";
 import { LiteralUnion, ValueOf } from "./types/internal";
-import { findIndex, getElement, includes, parseElement } from "./utils";
+import { deserializeNode, findIndex, getElement, includes, parseElement, serializeNode } from "./utils";
 
 /**
  * Options for the Flicking component
@@ -559,13 +559,6 @@ export interface GetStatusParams {
    */
   visiblePanelsOnly?: boolean;
 }
-
-// A cloned snapshot of each panel element captured by getStatus, keyed by the status panel entry.
-// setStatus restores panels by cloning these instead of re-parsing the serialized html string,
-// which would revive mutation-XSS payloads. Kept off the Status object so it stays a plain
-// JSON-serializable value; a JSON round-trip yields fresh entries that aren't in this map, so
-// panel DOM is left untouched. Weak keys let the snapshots be GC'd with their status entries.
-const panelSnapshots = new WeakMap<Status["panels"][0], HTMLElement>();
 
 class Flicking extends Component<FlickingEvents> {
   /**
@@ -1817,9 +1810,13 @@ class Flicking extends Component<FlickingEvents> {
 
         if (includePanelHTML) {
           panelInfo.html = panel.element.outerHTML;
-          // Keep a cloned snapshot of the actual node (off the Status object, in panelSnapshots)
-          // so setStatus can restore panels by cloning it instead of re-parsing the html string.
-          panelSnapshots.set(panelInfo, panel.element.cloneNode(true) as HTMLElement);
+          // Capture a structural (JSON-safe) snapshot of the node tree. setStatus rebuilds panels
+          // from this via DOM APIs instead of parsing the html string, which would revive
+          // mutation-XSS payloads; being JSON-safe, it also restores panels after a reload.
+          const node = serializeNode(panel.element);
+          if (node) {
+            panelInfo.node = node;
+          }
         }
 
         return panelInfo;
@@ -1864,14 +1861,11 @@ class Flicking extends Component<FlickingEvents> {
     const renderer = this._renderer;
     const control = this._control;
 
-    // Rebuild panels only from the captured node snapshots by cloning them, never by re-parsing
-    // the serialized `html` string — an `outerHTML`→`innerHTML` round-trip can revive a
-    // mutation-XSS payload that was inert on first render. After a JSON round-trip the status
-    // entries are fresh objects absent from panelSnapshots, so panel DOM is left untouched (only
-    // index/position below are restored) instead of being reconstructed from the string.
-    // (Also can't add/remove panels on external rendering.)
-    const snapshots = panels.map(panel => panelSnapshots.get(panel));
-    if (snapshots[0] && !this._renderExternal) {
+    // Rebuild panels from the structural node snapshots via DOM APIs, never by parsing the
+    // serialized `html` string — an `outerHTML`→`innerHTML` round-trip can revive a mutation-XSS
+    // payload that was inert on first render. The snapshot survives JSON, so this also restores
+    // panels after a reload/navigation. (Also can't add/remove panels on external rendering.)
+    if (panels[0]?.node && !this._renderExternal) {
       renderer.batchRemove({
         index: 0,
         deleteCount: this.panels.length,
@@ -1879,7 +1873,7 @@ class Flicking extends Component<FlickingEvents> {
       });
       renderer.batchInsert({
         index: 0,
-        elements: snapshots.map(snapshot => snapshot!.cloneNode(true) as HTMLElement),
+        elements: panels.map(panel => deserializeNode(panel.node!) as HTMLElement),
         hasDOMInElements: true
       });
     }

--- a/packages/flicking/src/types/external.ts
+++ b/packages/flicking/src/types/external.ts
@@ -40,7 +40,15 @@ export interface Status {
   panels: Array<{
     /** An index of the panel */
     index: number;
-    /** An `outerHTML` of the panel element */
+    /**
+     * An `outerHTML` of the panel element.
+     * @remarks
+     * This is informational only. {@link Flicking.setStatus} does **not** re-parse it to rebuild
+     * panels, since an `outerHTML`→`innerHTML` round-trip can revive a mutation-XSS payload that
+     * was inert on first render. Panels are restored by cloning a node snapshot captured at
+     * {@link Flicking.getStatus} time; after a JSON round-trip drops that snapshot, panel DOM is
+     * left untouched and only index/position restore.
+     */
     html?: string;
   }>;
 }

--- a/packages/flicking/src/types/external.ts
+++ b/packages/flicking/src/types/external.ts
@@ -22,6 +22,30 @@ export interface Plugin {
 }
 
 /**
+ * A JSON-safe structural representation of a panel element, captured by {@link Flicking.getStatus}.
+ * @remarks
+ * {@link Flicking.setStatus} rebuilds panels from this using DOM APIs (`createElement`/`setAttribute`),
+ * never by parsing HTML. This preserves the exact node tree — content that is inert on first render
+ * (e.g. an `<img>` that exists only as raw text inside `<style>`) stays inert — so it never revives a
+ * mutation-XSS payload, yet survives JSON serialization so panels restore correctly after a
+ * reload/navigation.
+ */
+export interface SerializedNode {
+  /** Element tag name. Absent for text/comment nodes. */
+  tag?: string;
+  /** Element namespace URI. Present only for non-HTML elements (e.g. SVG/MathML). */
+  ns?: string;
+  /** Element attributes as `[name, value]`, or `[name, value, namespaceURI]` for namespaced ones. */
+  attrs?: Array<[string, string] | [string, string, string]>;
+  /** Child nodes. */
+  children?: SerializedNode[];
+  /** Text node data. */
+  text?: string;
+  /** Comment node data. */
+  comment?: string;
+}
+
+/**
  * Flicking Status returned by {@link Flicking.getStatus}
  */
 export interface Status {
@@ -43,13 +67,16 @@ export interface Status {
     /**
      * An `outerHTML` of the panel element.
      * @remarks
-     * This is informational only. {@link Flicking.setStatus} does **not** re-parse it to rebuild
-     * panels, since an `outerHTML`→`innerHTML` round-trip can revive a mutation-XSS payload that
-     * was inert on first render. Panels are restored by cloning a node snapshot captured at
-     * {@link Flicking.getStatus} time; after a JSON round-trip drops that snapshot, panel DOM is
-     * left untouched and only index/position restore.
+     * Informational only. {@link Flicking.setStatus} does **not** parse it to rebuild panels, since an
+     * `outerHTML`→`innerHTML` round-trip can revive a mutation-XSS payload that was inert on first
+     * render. Panels are rebuilt from {@link node} instead.
      */
     html?: string;
+    /**
+     * A structural snapshot of the panel element used to rebuild it safely (see {@link SerializedNode}).
+     * Present when `includePanelHTML` is `true`; this is what {@link Flicking.setStatus} restores from.
+     */
+    node?: SerializedNode;
   }>;
 }
 

--- a/packages/flicking/src/utils.ts
+++ b/packages/flicking/src/utils.ts
@@ -7,7 +7,7 @@ import { ALIGN, DIRECTION } from "./constants/values";
 import * as ERROR from "./error/codes";
 import FlickingError from "./error/FlickingError";
 import Flicking, { FlickingOptions } from "./Flicking";
-import { ElementLike } from "./types/external";
+import { ElementLike, SerializedNode } from "./types/external";
 import { LiteralUnion, Merged, ValueOf } from "./types/internal";
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -197,6 +197,86 @@ export const parseElement = (element: ElementLike | ElementLike[]): HTMLElement[
   });
 
   return elements;
+};
+
+const HTML_NS = "http://www.w3.org/1999/xhtml";
+
+/**
+ * Serialize a DOM node into a JSON-safe structure that {@link deserializeNode} can rebuild without
+ * HTML parsing. Unlike an `outerHTML`→`innerHTML` round-trip, this preserves the exact node tree
+ * (e.g. an `<img>` that exists only as raw text inside `<style>` stays text), so it never elevates
+ * inert content into an executable element — safe against mutation-XSS.
+ */
+export const serializeNode = (node: Node): SerializedNode | null => {
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const el = node as Element;
+    const serialized: SerializedNode = { tag: el.tagName };
+    const ns = el.namespaceURI;
+
+    if (ns && ns !== HTML_NS) {
+      serialized.ns = ns;
+    }
+    if (el.attributes.length) {
+      serialized.attrs = toArray(el.attributes).map(attr =>
+        attr.namespaceURI ? [attr.name, attr.value, attr.namespaceURI] : [attr.name, attr.value]
+      );
+    }
+
+    const children = toArray(node.childNodes)
+      .map(serializeNode)
+      .filter((child): child is SerializedNode => child != null);
+    if (children.length) {
+      serialized.children = children;
+    }
+
+    return serialized;
+  }
+  if (node.nodeType === Node.TEXT_NODE) {
+    return { text: (node as Text).data };
+  }
+  if (node.nodeType === Node.COMMENT_NODE) {
+    return { comment: (node as Comment).data };
+  }
+
+  return null;
+};
+
+/**
+ * Rebuild a DOM node from {@link serializeNode}'s output using DOM APIs only (no HTML parsing),
+ * faithfully reproducing the original: inert content stays inert, authored content stays as authored.
+ */
+export const deserializeNode = (data: SerializedNode): Node | null => {
+  if (data.text != null) {
+    return document.createTextNode(data.text);
+  }
+  if (data.comment != null) {
+    return document.createComment(data.comment);
+  }
+  if (data.tag == null) {
+    return null;
+  }
+
+  const el = data.ns ? document.createElementNS(data.ns, data.tag) : document.createElement(data.tag);
+
+  if (data.attrs) {
+    data.attrs.forEach(([name, value, ns]) => {
+      if (ns) {
+        el.setAttributeNS(ns, name, value);
+      } else {
+        el.setAttribute(name, value);
+      }
+    });
+  }
+  if (data.children) {
+    data.children.forEach(child => {
+      const childNode = deserializeNode(child);
+      if (childNode) {
+        el.appendChild(childNode);
+      }
+    });
+  }
+
+  return el;
 };
 
 export const getMinusCompensatedIndex = (idx: number, max: number) =>

--- a/packages/test-flicking/unit/CrossFlicking.spec.ts
+++ b/packages/test-flicking/unit/CrossFlicking.spec.ts
@@ -17,6 +17,53 @@ describe("CrossFlicking", () => {
     });
   });
 
+  describe("Security", () => {
+    // 최초 파싱에서는 img가 <style>의 raw text라 무해하지만,
+    // innerHTML/outerHTML 직렬화 후 재파싱하면 실제 <img> 요소로 살아나는 mXSS 페이로드
+    const MXSS_PAYLOAD =
+      '<math><mtext><table><mglyph><style><img src="x" onerror="window.__xssTriggered = true"></style></mglyph></table></mtext></math>';
+
+    beforeEach(() => {
+      (window as any).__xssTriggered = false;
+    });
+
+    it("should not revive mXSS payloads in panel content while creating the cross structure", async () => {
+      const payloadPanel = El.panel().setWidth("100%").setHeight(1000);
+      payloadPanel.el.innerHTML = MXSS_PAYLOAD;
+      const el = El.viewport("1000px", "100%").add(
+        El.camera().add(payloadPanel, El.panel().setWidth("100%").setHeight(1000))
+      );
+
+      // 최초 파싱 시점에는 img가 요소로 존재하지 않아야 한다 (전제 조건)
+      expect(el.el.querySelector("img")).toBeNull();
+
+      const flicking = await createCrossFlicking(el);
+
+      expect(flicking.element.querySelector("img")).toBeNull();
+      expect((window as any).__xssTriggered).toBe(false);
+    });
+
+    it("should not revive mXSS payloads in grouped panels while creating the cross structure", async () => {
+      const payloadPanel = El.panel().setWidth("100%").setHeight(1000).setAttribute("data-cross-groupkey", "0");
+      payloadPanel.el.innerHTML = MXSS_PAYLOAD;
+      const el = El.viewport("1000px", "100%").add(
+        El.camera().add(
+          payloadPanel,
+          El.panel().setWidth("100%").setHeight(1000).setAttribute("data-cross-groupkey", "0"),
+          El.panel().setWidth("100%").setHeight(1000).setAttribute("data-cross-groupkey", "1"),
+          El.panel().setWidth("100%").setHeight(1000).setAttribute("data-cross-groupkey", "1")
+        )
+      );
+
+      expect(el.el.querySelector("img")).toBeNull();
+
+      const flicking = await createCrossFlicking(el);
+
+      expect(flicking.element.querySelector("img")).toBeNull();
+      expect((window as any).__xssTriggered).toBe(false);
+    });
+  });
+
   describe("Options", () => {
     describe("sideOptions", () => {
       it("should apply sideOptions to side flicking instances.", async () => {

--- a/packages/test-flicking/unit/Flicking.spec.ts
+++ b/packages/test-flicking/unit/Flicking.spec.ts
@@ -2633,6 +2633,81 @@ describe("Flicking", () => {
         expect(flicking.camera.position).not.toBe(prevPosition);
         expect(flicking.camera.range).not.toEqual(prevRange);
       });
+
+      describe("Security", () => {
+        // Inert on first parse (img is <style> raw text in foreign content), but revives into a
+        // real <img> element once serialized to outerHTML and re-parsed via innerHTML (mXSS).
+        const MXSS_PAYLOAD =
+          '<math><mtext><table><mglyph><style><img src="x" onerror="window.__statusXss = true"></style></mglyph></table></mtext></math>';
+
+        const createFlickingWithPayload = () => {
+          const payloadPanel = El.panel().setWidth("100%").setHeight(300);
+          payloadPanel.el.innerHTML = MXSS_PAYLOAD;
+          return createFlicking(
+            El.viewport("1000px", "100%").add(El.camera().add(payloadPanel, El.panel().setWidth("100%").setHeight(300)))
+          );
+        };
+
+        beforeEach(() => {
+          (window as any).__statusXss = false;
+        });
+
+        it("should not revive an mXSS payload when restoring within the same session", async () => {
+          const flicking = await createFlickingWithPayload();
+
+          const status = flicking.getStatus({ includePanelHTML: true });
+          flicking.setStatus(status);
+          await waitTime(200);
+
+          // cloneNode of the inert snapshot keeps it inert: no <img> element is ever created
+          expect(flicking.element.querySelector("img")).toBeNull();
+          expect((window as any).__statusXss).toBe(false);
+        });
+
+        it("should not revive an mXSS payload when restoring a JSON-serialized status", async () => {
+          const flicking = await createFlickingWithPayload();
+
+          const status = flicking.getStatus({ includePanelHTML: true });
+          // JSON round-trip drops the live element snapshot, leaving only the serialized html string
+          const restored = JSON.parse(JSON.stringify(status));
+          flicking.setStatus(restored);
+          await waitTime(200);
+
+          // The html string is never re-parsed, so the inert payload stays inert: no <img> revived
+          expect(flicking.element.querySelector("img")).toBeNull();
+          expect((window as any).__statusXss).toBe(false);
+        });
+
+        it("should not rebuild panels from a JSON-serialized status (only index/position restore)", async () => {
+          const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { defaultIndex: 1 });
+          const originalFirstPanelEl = flicking.panels[0].element;
+
+          const status = flicking.getStatus({ includePanelHTML: true });
+          void flicking.moveTo(0, 0);
+          const restored = JSON.parse(JSON.stringify(status));
+          flicking.setStatus(restored);
+
+          // Panel DOM is left intact (not recreated from the html string) ...
+          expect(flicking.panels[0].element).toBe(originalFirstPanelEl);
+          // ... while index is still restored.
+          expect(flicking.index).toBe(1);
+        });
+
+        it("should keep the status a plain JSON-serializable object", async () => {
+          const flicking = await createFlickingWithPayload();
+
+          const status = flicking.getStatus({ includePanelHTML: true });
+
+          // The node snapshot is held off the status object (in a WeakMap), so the status carries
+          // only serializable data and survives a JSON round-trip intact.
+          expect(Object.keys(status.panels[0]).sort()).toEqual(["html", "index"]);
+          expect(() => JSON.stringify(status)).not.toThrow();
+
+          const restored = JSON.parse(JSON.stringify(status));
+          expect(restored.panels[0].index).toBe(status.panels[0].index);
+          expect(restored.panels[0].html).toBe(status.panels[0].html);
+        });
+      });
     });
 
     describe("resize()", () => {

--- a/packages/test-flicking/unit/Flicking.spec.ts
+++ b/packages/test-flicking/unit/Flicking.spec.ts
@@ -2634,6 +2634,72 @@ describe("Flicking", () => {
         expect(flicking.camera.range).not.toEqual(prevRange);
       });
 
+      it("should reproduce panel content (attributes + nested structure) when restoring in the same session", async () => {
+        const richPanel = El.panel().setWidth("100%").setHeight(300);
+        richPanel.el.setAttribute("data-id", "p0");
+        richPanel.el.innerHTML = '<h3 class="title">Hello</h3><p>world <b>!</b></p>';
+        const flicking = await createFlicking(
+          El.viewport("1000px", "100%").add(El.camera().add(richPanel, El.panel().setWidth("100%").setHeight(300)))
+        );
+        const expectedHTML = flicking.panels[0].element.innerHTML;
+
+        flicking.setStatus(flicking.getStatus({ includePanelHTML: true }));
+
+        expect(flicking.panels[0].element.getAttribute("data-id")).toBe("p0");
+        expect(flicking.panels[0].element.innerHTML).toBe(expectedHTML);
+      });
+
+      it("should reconstruct every panel's content faithfully from a JSON-serialized status", async () => {
+        const pageA = await createFlicking(
+          El.viewport("1000px", "100%").add(
+            El.camera().add(
+              ...range(3).map(i => {
+                const panel = El.panel().setWidth("100%").setHeight(300);
+                panel.el.innerHTML = `<span class="c${i}">panel ${i}</span>`;
+                return panel;
+              })
+            )
+          ),
+          { defaultIndex: 2 }
+        );
+        const expectedHTML = pageA.panels.map(panel => panel.element.innerHTML);
+        const stored = JSON.stringify(pageA.getStatus({ includePanelHTML: true }));
+
+        // Reload into an empty flicking, then restore from the JSON string.
+        const reloaded = await createFlicking(El.EMPTY);
+        reloaded.setStatus(JSON.parse(stored));
+
+        expect(reloaded.panels.length).toBe(3);
+        expect(reloaded.panels.map(panel => panel.element.innerHTML)).toEqual(expectedHTML);
+        expect(reloaded.index).toBe(2);
+      });
+
+      it("should capture the panel snapshot at getStatus time, not setStatus time", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL);
+        const status = flicking.getStatus({ includePanelHTML: true });
+
+        // Mutate the live panel AFTER capturing the status.
+        flicking.currentPanel.element.classList.add("added-after-getStatus");
+        flicking.setStatus(status);
+
+        expect(flicking.currentPanel.element.classList.contains("added-after-getStatus")).toBe(false);
+      });
+
+      it("should not rebuild panels when includePanelHTML is false, but still restore index", async () => {
+        const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { defaultIndex: 2 });
+        const firstPanelEl = flicking.panels[0].element;
+        const status = flicking.getStatus(); // no includePanelHTML -> no node snapshot
+
+        void flicking.moveTo(0, 0);
+        flicking.setStatus(status);
+
+        // Panel DOM is left intact (no reconstruction) ...
+        expect(flicking.panels[0].element).toBe(firstPanelEl);
+        expect(flicking.panels.length).toBe(3);
+        // ... while index is restored.
+        expect(flicking.index).toBe(2);
+      });
+
       describe("Security", () => {
         // Inert on first parse (img is <style> raw text in foreign content), but revives into a
         // real <img> element once serialized to outerHTML and re-parsed via innerHTML (mXSS).
@@ -2659,38 +2725,28 @@ describe("Flicking", () => {
           flicking.setStatus(status);
           await waitTime(200);
 
-          // cloneNode of the inert snapshot keeps it inert: no <img> element is ever created
+          // The structural snapshot rebuilds the inert tree faithfully: no <img> element is created
           expect(flicking.element.querySelector("img")).toBeNull();
           expect((window as any).__statusXss).toBe(false);
         });
 
-        it("should not revive an mXSS payload when restoring a JSON-serialized status", async () => {
-          const flicking = await createFlickingWithPayload();
+        it("should reconstruct panels from a JSON-serialized status without reviving payloads", async () => {
+          // Simulate save-on-page-A -> reload -> restore: only the JSON string survives.
+          const pageA = await createFlickingWithPayload();
+          const stored = JSON.stringify(pageA.getStatus({ includePanelHTML: true }));
 
-          const status = flicking.getStatus({ includePanelHTML: true });
-          // JSON round-trip drops the live element snapshot, leaving only the serialized html string
-          const restored = JSON.parse(JSON.stringify(status));
-          flicking.setStatus(restored);
+          // Reload into a brand-new flicking whose panels are NOT in the DOM.
+          const reloaded = await createFlicking(El.EMPTY);
+          expect(reloaded.panels.length).toBe(0);
+
+          reloaded.setStatus(JSON.parse(stored));
           await waitTime(200);
 
-          // The html string is never re-parsed, so the inert payload stays inert: no <img> revived
-          expect(flicking.element.querySelector("img")).toBeNull();
+          // Panels ARE reconstructed from the serialized status (reload restore keeps working) ...
+          expect(reloaded.panels.length).toBe(2);
+          // ... while the inert payload stays inert (no <img> revived, no script runs).
+          expect(reloaded.element.querySelector("img")).toBeNull();
           expect((window as any).__statusXss).toBe(false);
-        });
-
-        it("should not rebuild panels from a JSON-serialized status (only index/position restore)", async () => {
-          const flicking = await createFlicking(El.DEFAULT_HORIZONTAL, { defaultIndex: 1 });
-          const originalFirstPanelEl = flicking.panels[0].element;
-
-          const status = flicking.getStatus({ includePanelHTML: true });
-          void flicking.moveTo(0, 0);
-          const restored = JSON.parse(JSON.stringify(status));
-          flicking.setStatus(restored);
-
-          // Panel DOM is left intact (not recreated from the html string) ...
-          expect(flicking.panels[0].element).toBe(originalFirstPanelEl);
-          // ... while index is still restored.
-          expect(flicking.index).toBe(1);
         });
 
         it("should keep the status a plain JSON-serializable object", async () => {
@@ -2698,14 +2754,13 @@ describe("Flicking", () => {
 
           const status = flicking.getStatus({ includePanelHTML: true });
 
-          // The node snapshot is held off the status object (in a WeakMap), so the status carries
-          // only serializable data and survives a JSON round-trip intact.
-          expect(Object.keys(status.panels[0]).sort()).toEqual(["html", "index"]);
+          // The panel carries only serializable data (a structural node snapshot, not a live element),
+          // so the status survives a JSON round-trip intact.
+          expect(Object.keys(status.panels[0]).sort()).toEqual(["html", "index", "node"]);
           expect(() => JSON.stringify(status)).not.toThrow();
 
           const restored = JSON.parse(JSON.stringify(status));
-          expect(restored.panels[0].index).toBe(status.panels[0].index);
-          expect(restored.panels[0].html).toBe(status.panels[0].html);
+          expect(restored.panels[0].node).toEqual(status.panels[0].node);
         });
       });
     });

--- a/packages/test-flicking/unit/utils.spec.ts
+++ b/packages/test-flicking/unit/utils.spec.ts
@@ -5,6 +5,7 @@ import Flicking from "~/Flicking";
 import {
   checkExistence,
   clamp,
+  deserializeNode,
   getDirection,
   getElement,
   getElementSize,
@@ -18,11 +19,12 @@ import {
   parseBounce,
   parseCSSSizeValue,
   parseElement,
+  serializeNode,
   toArray
 } from "~/utils";
 
 import El from "./helper/El";
-import { cleanup, createFlicking, createSandbox, NullClass, range } from "./helper/test-util";
+import { cleanup, createFlicking, createSandbox, NullClass, range, waitTime } from "./helper/test-util";
 
 describe("Util Functions", () => {
   describe("merge", () => {
@@ -469,6 +471,169 @@ describe("Util Functions", () => {
         }
         expect(err).toBeInstanceOf(FlickingError);
         expect(err.code).toBe(ERROR.CODE.WRONG_TYPE);
+      });
+    });
+  });
+
+  describe("serializeNode / deserializeNode", () => {
+    const XLINK_NS = "http://www.w3.org/1999/xlink";
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const MATH_NS = "http://www.w3.org/1998/Math/MathML";
+
+    const roundTrip = (el: Node): Node | null => deserializeNode(serializeNode(el)!);
+    const jsonRoundTrip = (el: Node): Node | null => deserializeNode(JSON.parse(JSON.stringify(serializeNode(el))));
+
+    describe("serializeNode", () => {
+      it("should serialize an element into tag + attrs + children", () => {
+        const el = document.createElement("div");
+        el.setAttribute("class", "panel");
+        el.setAttribute("data-x", "1");
+        el.appendChild(document.createTextNode("hi"));
+
+        const serialized = serializeNode(el)!;
+
+        expect(serialized.tag).toBe("DIV");
+        expect(serialized.ns).toBeUndefined(); // HTML namespace is the default, so it is omitted
+        expect(serialized.attrs).toEqual([
+          ["class", "panel"],
+          ["data-x", "1"]
+        ]);
+        expect(serialized.children).toEqual([{ text: "hi" }]);
+      });
+
+      it("should serialize a text node and a comment node", () => {
+        expect(serializeNode(document.createTextNode("some text"))).toEqual({ text: "some text" });
+        expect(serializeNode(document.createComment("a comment"))).toEqual({ comment: "a comment" });
+      });
+
+      it("should record the namespace URI for non-HTML elements", () => {
+        const svg = document.createElementNS(SVG_NS, "svg");
+        const serialized = serializeNode(svg)!;
+
+        expect(serialized.tag).toBe("svg");
+        expect(serialized.ns).toBe(SVG_NS);
+      });
+
+      it("should record the namespace URI for namespaced attributes", () => {
+        const a = document.createElementNS(SVG_NS, "a");
+        a.setAttributeNS(XLINK_NS, "xlink:href", "#target");
+
+        const serialized = serializeNode(a)!;
+
+        expect(serialized.attrs).toEqual([["xlink:href", "#target", XLINK_NS]]);
+      });
+
+      it("should omit empty attrs / children", () => {
+        const serialized = serializeNode(document.createElement("span"))!;
+
+        expect(serialized).toEqual({ tag: "SPAN" });
+      });
+
+      it("should return null for unsupported node types", () => {
+        const frag = document.createDocumentFragment();
+
+        expect(serializeNode(frag)).toBeNull();
+      });
+    });
+
+    describe("deserializeNode", () => {
+      it("should return null when the data has no tag / text / comment", () => {
+        expect(deserializeNode({})).toBeNull();
+      });
+
+      it("should build a text node and a comment node", () => {
+        const text = deserializeNode({ text: "hello" })!;
+        const comment = deserializeNode({ comment: "note" })!;
+
+        expect(text.nodeType).toBe(Node.TEXT_NODE);
+        expect((text as Text).data).toBe("hello");
+        expect(comment.nodeType).toBe(Node.COMMENT_NODE);
+        expect((comment as Comment).data).toBe("note");
+      });
+
+      it("should build a non-HTML element with createElementNS", () => {
+        const el = deserializeNode({ tag: "svg", ns: SVG_NS }) as Element;
+
+        expect(el.namespaceURI).toBe(SVG_NS);
+      });
+
+      it("should set namespaced attributes with setAttributeNS", () => {
+        const el = deserializeNode({ tag: "a", ns: SVG_NS, attrs: [["xlink:href", "#t", XLINK_NS]] }) as Element;
+
+        expect(el.getAttributeNS(XLINK_NS, "href")).toBe("#t");
+      });
+    });
+
+    describe("round-trip fidelity", () => {
+      it("should reproduce a nested element tree (attributes, order, text, comment)", () => {
+        const el = document.createElement("div");
+        el.innerHTML = '<span class="a" data-x="1">hi <b>bold</b><!-- c --></span>';
+
+        expect((roundTrip(el) as HTMLElement).outerHTML).toBe(el.outerHTML);
+      });
+
+      it("should preserve SVG namespaces and xlink attributes", () => {
+        const svg = document.createElementNS(SVG_NS, "svg");
+        const use = document.createElementNS(SVG_NS, "use");
+        use.setAttributeNS(XLINK_NS, "xlink:href", "#icon");
+        svg.appendChild(use);
+
+        const rebuilt = roundTrip(svg) as Element;
+
+        expect(rebuilt.namespaceURI).toBe(SVG_NS);
+        expect(rebuilt.firstElementChild!.namespaceURI).toBe(SVG_NS);
+        expect(rebuilt.firstElementChild!.getAttributeNS(XLINK_NS, "href")).toBe("#icon");
+      });
+
+      it("should survive a JSON round-trip identically", () => {
+        const el = document.createElement("section");
+        el.innerHTML = '<h2 id="t">Title</h2><p class="body">text <em>x</em></p>';
+
+        expect((jsonRoundTrip(el) as HTMLElement).outerHTML).toBe(el.outerHTML);
+      });
+    });
+
+    describe("mutation-XSS safety", () => {
+      const MXSS =
+        '<math><mtext><table><mglyph><style><img src="x" onerror="window.__nodeXss = true"></style></mglyph></table></mtext></math>';
+
+      beforeEach(() => {
+        (window as any).__nodeXss = false;
+      });
+
+      it("should keep an inert payload inert (no <img> element revived)", () => {
+        const el = document.createElement("div");
+        el.innerHTML = MXSS;
+        // Precondition: on first parse the img is <style> raw text, not an element
+        expect(el.querySelector("img")).toBeNull();
+
+        const rebuilt = roundTrip(el) as HTMLElement;
+
+        expect(rebuilt.querySelector("img")).toBeNull();
+      });
+
+      it("should keep an inert payload inert across a JSON round-trip", async () => {
+        const el = document.createElement("div");
+        el.innerHTML = MXSS;
+
+        const rebuilt = jsonRoundTrip(el) as HTMLElement;
+        document.body.appendChild(rebuilt);
+        await waitTime(100);
+
+        expect(rebuilt.querySelector("img")).toBeNull();
+        expect((window as any).__nodeXss).toBe(false);
+        rebuilt.remove();
+      });
+
+      it("should faithfully reproduce a genuinely authored element (no stripping)", () => {
+        // An author-inserted <img> IS a real element; structural restore keeps it (unlike sanitizing).
+        const el = document.createElement("div");
+        el.innerHTML = '<img src="/logo.png" alt="logo"><iframe title="f"></iframe>';
+
+        const rebuilt = roundTrip(el) as HTMLElement;
+
+        expect(rebuilt.querySelector("img")!.getAttribute("src")).toBe("/logo.png");
+        expect(rebuilt.querySelector("iframe")!.getAttribute("title")).toBe("f");
       });
     });
   });


### PR DESCRIPTION
Flicking had an a DOM XSS vulnerability where an mXSS payload was revived as an actual element during the process of serializing panel content into innerHTML/outerHTML strings and subsequently re-parsing it.

The structure is constructed solely through node cloning using `cloneNode` and `appendChild`.